### PR TITLE
release: prepare v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ npm run build
 构建结果位于：
 
 - `build/package/`：未压缩插件目录
-- `build/mktero-0.1.0.xpi`：可安装插件包
-- `build/mktero-0.1.0.xpi.sha256`：只引用 XPI 文件名的 SHA-256 校验文件
+- `build/mktero-0.2.0.xpi`：可安装插件包
+- `build/mktero-0.2.0.xpi.sha256`：只引用 XPI 文件名的 SHA-256 校验文件
 - `build/updates.json`：与当前版本、下载地址和 XPI 哈希一致的 Zotero 更新清单
 
 XPI 中的文件顺序和时间戳固定；相同源码与依赖连续构建会得到相同的 XPI 哈希。
@@ -174,8 +174,8 @@ scripts/build.mjs  esbuild 与 XPI 打包脚本
 随后创建带 `v` 前缀、与清单版本完全一致的标签：
 
 ```bash
-git tag v0.1.0
-git push origin v0.1.0
+git tag v0.2.0
+git push origin v0.2.0
 ```
 
 标签推送后，[Release 工作流](./.github/workflows/release.yml)会自动执行语法检查、完整测试

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@codemirror/commands": "6.10.4",
         "@codemirror/lang-markdown": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -36,7 +36,7 @@ test('declares the scalable Mktero logo for extension surfaces', () => {
 });
 
 test('keeps the installable package version metadata consistent', () => {
-    assert.equal(manifest.version, '0.1.0');
+    assert.equal(manifest.version, '0.2.0');
     assert.equal(packageMetadata.version, manifest.version);
     assert.equal(packageLock.version, manifest.version);
     assert.equal(packageLock.packages[''].version, manifest.version);


### PR DESCRIPTION
## Summary

- bump Mktero version metadata from 0.1.0 to 0.2.0
- update manifest consistency coverage and README artifact examples
- prepare XPI, checksum, and update metadata naming for the v0.2.0 release

## Verification

- npm run check
- npm test (414/414)
- npm run build
- shasum -a 256 -c mktero-0.2.0.xpi.sha256
- Standards and Spec reviews passed with no findings

## Release boundary

This PR prepares the release only. Create and push the v0.2.0 tag after this PR is merged to trigger the GitHub Release workflow.