### PR TITLE
docs: add Mktero landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Zotero](https://img.shields.io/badge/Zotero-7%20%7C%208%20%7C%209-cc2936.svg)](https://www.zotero.org/)
 
+[产品介绍页](https://tenglvjun.github.io/mktero/) · [下载最新版本](https://github.com/tenglvjun/mktero/releases/latest)
+
 Mktero 是一个适用于 Zotero 7、8 和 9 的 PDF 阅读插件。它通过 MinerU 将本地
 PDF 转换为 Markdown，并在 Zotero 标签页中以只读、行内渲染的方式展示正文、
 公式、表格、图片和学术引用。

--- a/docs/assets/mktero.svg
+++ b/docs/assets/mktero.svg
@@ -1,0 +1,5 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="1.25" y="2.25" width="13.5" height="11.5" rx="2.25" fill="#F4F7FC" stroke="#4072E5" stroke-width="1.5"/>
+  <path d="M3.5 10.5V5.75L5.75 8L8 5.75V10.5" stroke="#4072E5" stroke-width="1.45" stroke-linecap="round" stroke-linejoin="round"/>
+  <path d="M11.25 5.75V10.25M9.5 8.5L11.25 10.25L13 8.5" stroke="#4072E5" stroke-width="1.45" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,167 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="Mktero is a source-linked reflow reader for complex Zotero PDFs.">
+    <meta name="theme-color" content="#15233b">
+    <meta property="og:title" content="Mktero | Read complex papers without losing the evidence">
+    <meta property="og:description" content="A source-linked reflow reader for Zotero PDFs, with annotations that stay connected to the original paper.">
+    <meta property="og:type" content="website">
+    <meta property="og:image" content="assets/mktero-demo.gif">
+    <title>Mktero | Source-linked reading for Zotero</title>
+    <link rel="icon" type="image/svg+xml" href="assets/mktero.svg">
+    <link rel="stylesheet" href="site.css">
+</head>
+<body>
+    <header class="site-header">
+        <a class="brand" href="#top" aria-label="Mktero home">
+            <img src="assets/mktero.svg" alt="" width="24" height="24">
+            <span>Mktero</span>
+        </a>
+        <nav class="site-nav" aria-label="Primary navigation">
+            <a href="#workflow" data-i18n="nav.workflow">工作流</a>
+            <a href="#evidence" data-i18n="nav.evidence">证据链</a>
+            <a href="#privacy" data-i18n="nav.privacy">隐私</a>
+            <a href="https://github.com/tenglvjun/mktero" target="_blank" rel="noreferrer">GitHub <span aria-hidden="true">↗</span></a>
+            <button class="language-button" type="button" data-language-toggle aria-label="Switch to English">EN</button>
+        </nav>
+    </header>
+
+    <main id="top">
+        <section class="hero" aria-labelledby="hero-title">
+            <div class="hero-copy">
+                <p class="eyebrow" data-i18n="hero.eyebrow">ZOTERO READING LAYER</p>
+                <h1 id="hero-title" data-i18n="hero.title">把复杂论文重排成好读的正文，同时保留每条证据回到 PDF 的路径。</h1>
+                <p class="hero-lede" data-i18n="hero.lede">Mktero 是一个面向 Zotero 的来源关联重排阅读器。阅读双栏、公式和表格密集的论文，在 Markdown 中标注，再回到原始 PDF 核对。</p>
+                <div class="hero-actions">
+                    <a class="button button-primary" href="https://github.com/tenglvjun/mktero/releases/latest" target="_blank" rel="noreferrer">
+                        <span data-i18n="hero.download">下载最新版本</span><span aria-hidden="true">↗</span>
+                    </a>
+                    <a class="button button-quiet" href="https://github.com/tenglvjun/mktero/discussions" target="_blank" rel="noreferrer">
+                        <span data-i18n="hero.beta">加入种子用户</span><span aria-hidden="true">↗</span>
+                    </a>
+                </div>
+                <p class="hero-meta"><span data-i18n="hero.support">支持 Zotero 7、8 和 9</span><span class="meta-separator" aria-hidden="true">·</span><span data-i18n="hero.openSource">MIT 开源</span></p>
+            </div>
+            <div class="hero-demo" aria-label="Mktero demonstration">
+                <div class="demo-topline"><span class="demo-dot"></span><span data-i18n="hero.demoLabel">从 Zotero PDF 到可核验阅读</span></div>
+                <img src="assets/mktero-demo.gif" alt="Mktero converts a Zotero PDF into a reflowed Markdown reading view with annotations and source navigation">
+                <div class="demo-caption"><span data-i18n="hero.demoCaption">重排阅读 · Zotero 标注 · PDF 来源跳转</span><span class="caption-arrow" aria-hidden="true">↘</span></div>
+            </div>
+        </section>
+
+        <section class="proof-strip" aria-label="Mktero product promise">
+            <p data-i18n="proof">不是另一个 Markdown 编辑器。Mktero 让 PDF 成为事实源，让阅读、标注和摘录保持可核验。</p>
+        </section>
+
+        <section class="section workflow-section" id="workflow" aria-labelledby="workflow-title">
+            <div class="section-heading">
+                <p class="eyebrow" data-i18n="workflow.eyebrow">THE READING LOOP</p>
+                <h2 id="workflow-title" data-i18n="workflow.title">一篇论文，三步进入你的阅读工作流。</h2>
+                <p data-i18n="workflow.lede">Mktero 把转换结果留在 Zotero 的阅读上下文里，不迫使你在 PDF、笔记和浏览器之间来回切换。</p>
+            </div>
+            <div class="workflow-grid">
+                <article class="workflow-item">
+                    <div class="step-number">01</div>
+                    <h3 data-i18n="workflow.one.title">打开</h3>
+                    <p data-i18n="workflow.one.body">从 PDF 阅读器工具栏或文库右键打开。Mktero 使用 MinerU 解析正文、公式、表格、图片和引用。</p>
+                </article>
+                <article class="workflow-item">
+                    <div class="step-number">02</div>
+                    <h3 data-i18n="workflow.two.title">阅读与标注</h3>
+                    <p data-i18n="workflow.two.body">在连续、只读的 Markdown 视图中搜索、浏览目录、预览引用和图表，并直接创建 Zotero 标注。</p>
+                </article>
+                <article class="workflow-item">
+                    <div class="step-number">03</div>
+                    <h3 data-i18n="workflow.three.title">核对与复用</h3>
+                    <p data-i18n="workflow.three.body">点击来源回到 PDF 原位，或复制带论文标题、物理页码和 Zotero 回链的摘录。</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section evidence-section" id="evidence" aria-labelledby="evidence-title">
+            <div class="evidence-visual" aria-hidden="true">
+                <div class="paper-line line-wide"></div>
+                <div class="paper-line line-short"></div>
+                <div class="paper-line line-medium"></div>
+                <div class="evidence-highlight">
+                    <span class="evidence-pin">↗</span>
+                    <span data-i18n="evidence.pin">第 4 页 · 来源块</span>
+                </div>
+                <div class="paper-line line-wide"></div>
+                <div class="paper-line line-medium"></div>
+                <div class="paper-line line-short"></div>
+                <div class="evidence-note"><span class="note-mark"></span><span data-i18n="evidence.note">同步到 Zotero 的高亮</span></div>
+            </div>
+            <div class="evidence-copy">
+                <p class="eyebrow" data-i18n="evidence.eyebrow">READ WITH PROOF</p>
+                <h2 id="evidence-title" data-i18n="evidence.title">每一次摘录，都有回去的路。</h2>
+                <p data-i18n="evidence.lede">MinerU 的内容块与 PDF 页码、区域坐标建立关联。Mktero 只在匹配可靠时显示跳转，宁可少一个按钮，也不猜测原文位置。</p>
+                <ul class="feature-list">
+                    <li><span class="list-marker">↗</span><span data-i18n="evidence.itemOne">正文、公式、表格和图表都可以回到 PDF 来源</span></li>
+                    <li><span class="list-marker">✓</span><span data-i18n="evidence.itemTwo">Markdown 与 Zotero PDF 标注保持同步</span></li>
+                    <li><span class="list-marker">⌘</span><span data-i18n="evidence.itemThree">复制摘录时保留页码与 Zotero 回链</span></li>
+                </ul>
+            </div>
+        </section>
+
+        <section class="section features-section" aria-labelledby="features-title">
+            <div class="section-heading compact-heading">
+                <p class="eyebrow" data-i18n="features.eyebrow">MADE FOR PAPERS</p>
+                <h2 id="features-title" data-i18n="features.title">为真正难读的论文而做。</h2>
+            </div>
+            <div class="features-grid">
+                <article class="feature-item">
+                    <div class="feature-icon icon-blue">Aa</div>
+                    <h3 data-i18n="features.one.title">连续正文</h3>
+                    <p data-i18n="features.one.body">把双栏布局、OCR 断行、公式和表格整理成适合连续阅读的视图。</p>
+                </article>
+                <article class="feature-item">
+                    <div class="feature-icon icon-coral">#</div>
+                    <h3 data-i18n="features.two.title">学术结构</h3>
+                    <p data-i18n="features.two.body">目录、引用预览、图表引用、图片放大和 KaTeX 公式都保留在阅读上下文中。</p>
+                </article>
+                <article class="feature-item">
+                    <div class="feature-icon icon-teal">↗</div>
+                    <h3 data-i18n="features.three.title">来源意识</h3>
+                    <p data-i18n="features.three.body">不把 Markdown 当作新的事实源。PDF 仍是原文，Mktero 负责让它更容易读和核对。</p>
+                </article>
+                <article class="feature-item">
+                    <div class="feature-icon icon-gold">⌘</div>
+                    <h3 data-i18n="features.four.title">本地缓存</h3>
+                    <p data-i18n="features.four.body">相同 PDF 可从本机缓存打开，避免每次重新上传和解析。</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="privacy-band" id="privacy" aria-labelledby="privacy-title">
+            <div>
+                <p class="eyebrow" data-i18n="privacy.eyebrow">KNOW WHERE YOUR PAPER GOES</p>
+                <h2 id="privacy-title" data-i18n="privacy.title">数据边界清楚，选择留给你。</h2>
+            </div>
+            <div class="privacy-copy">
+                <p data-i18n="privacy.body">首次转换或缓存未命中时，完整 PDF 会上传到 MinerU。API Token、Markdown、图片和标注缓存保存在本机 Zotero 配置文件中，未加密且不会通过 Zotero 同步。</p>
+                <a class="text-link" href="https://github.com/tenglvjun/mktero#缓存与隐私" target="_blank" rel="noreferrer"><span data-i18n="privacy.link">阅读完整隐私说明</span><span aria-hidden="true">↗</span></a>
+            </div>
+        </section>
+
+        <section class="closing-section" aria-labelledby="closing-title">
+            <p class="eyebrow" data-i18n="closing.eyebrow">START WITH ONE PAPER</p>
+            <h2 id="closing-title" data-i18n="closing.title">让下一篇论文更容易读懂，也更容易核对。</h2>
+            <div class="closing-actions">
+                <a class="button button-primary" href="https://github.com/tenglvjun/mktero/releases/latest" target="_blank" rel="noreferrer"><span data-i18n="closing.download">下载 Mktero</span><span aria-hidden="true">↗</span></a>
+                <a class="button button-outline" href="https://github.com/tenglvjun/mktero" target="_blank" rel="noreferrer"><span data-i18n="closing.source">查看源代码</span><span aria-hidden="true">↗</span></a>
+            </div>
+            <p class="closing-meta" data-i18n="closing.meta">需要 MinerU API Token · 支持 Zotero 7–9 · MIT License</p>
+        </section>
+    </main>
+
+    <footer class="site-footer">
+        <span>© <span data-current-year></span> Mktero</span>
+        <span data-i18n="footer">一个让学术阅读更可核验的 Zotero 插件。</span>
+        <a href="https://github.com/tenglvjun/mktero" target="_blank" rel="noreferrer">GitHub <span aria-hidden="true">↗</span></a>
+    </footer>
+    <script src="site.js"></script>
+</body>
+</html>

--- a/docs/site.css
+++ b/docs/site.css
@@ -1,0 +1,699 @@
+:root {
+    color-scheme: light;
+    --ink: #17243b;
+    --ink-muted: #5e6b7f;
+    --paper: #f8f9fb;
+    --white: #ffffff;
+    --line: #dce2eb;
+    --blue: #4072e5;
+    --blue-dark: #2b58bd;
+    --coral: #e98265;
+    --teal: #278c86;
+    --gold: #ca8a2e;
+    --shadow: 0 24px 54px rgba(20, 36, 62, 0.16);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    color: var(--ink);
+    background: var(--paper);
+    font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans SC", sans-serif;
+    line-height: 1.6;
+    text-rendering: optimizeLegibility;
+}
+
+a {
+    color: inherit;
+}
+
+button,
+a {
+    -webkit-tap-highlight-color: transparent;
+}
+
+:focus-visible {
+    outline: 3px solid rgba(64, 114, 229, 0.45);
+    outline-offset: 4px;
+}
+
+.site-header {
+    align-items: center;
+    background: rgba(21, 35, 59, 0.96);
+    color: #f8fbff;
+    display: flex;
+    justify-content: space-between;
+    min-height: 72px;
+    padding: 0 clamp(24px, 5vw, 80px);
+    position: relative;
+    z-index: 2;
+}
+
+.brand,
+.site-nav,
+.site-nav a {
+    align-items: center;
+    display: flex;
+}
+
+.brand {
+    font-size: 1.08rem;
+    font-weight: 750;
+    gap: 10px;
+    letter-spacing: 0.01em;
+    text-decoration: none;
+}
+
+.brand img {
+    background: #f4f7fc;
+    border-radius: 6px;
+    padding: 2px;
+}
+
+.site-nav {
+    gap: clamp(14px, 2.5vw, 30px);
+}
+
+.site-nav a {
+    color: #cbd5e5;
+    font-size: 0.88rem;
+    gap: 5px;
+    text-decoration: none;
+    transition: color 160ms ease;
+}
+
+.site-nav a:hover {
+    color: #ffffff;
+}
+
+.language-button {
+    background: transparent;
+    border: 1px solid rgba(216, 226, 241, 0.35);
+    border-radius: 999px;
+    color: #edf3ff;
+    cursor: pointer;
+    font: inherit;
+    font-size: 0.75rem;
+    font-weight: 750;
+    letter-spacing: 0.06em;
+    padding: 5px 10px;
+}
+
+.hero {
+    background: var(--ink);
+    color: #f8fbff;
+    overflow: hidden;
+    padding: clamp(52px, 6vw, 84px) clamp(24px, 7vw, 112px) clamp(42px, 5vw, 68px);
+    position: relative;
+}
+
+.hero::after {
+    background: var(--coral);
+    content: "";
+    height: 10px;
+    left: 0;
+    opacity: 0.9;
+    position: absolute;
+    top: 0;
+    width: 20%;
+}
+
+.hero-copy,
+.hero-demo,
+.section,
+.privacy-band,
+.closing-section,
+.site-footer {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1180px;
+}
+
+.hero-copy {
+    max-width: 850px;
+}
+
+.eyebrow {
+    color: #85a9ff;
+    font-size: 0.74rem;
+    font-weight: 800;
+    letter-spacing: 0.18em;
+    margin: 0 0 18px;
+}
+
+.hero h1 {
+    font-size: clamp(2.6rem, 5.4vw, 5.2rem);
+    letter-spacing: -0.055em;
+    line-height: 1.04;
+    margin: 0;
+    max-width: 1000px;
+}
+
+.hero-lede {
+    color: #c3cede;
+    font-size: clamp(1.05rem, 1.7vw, 1.28rem);
+    line-height: 1.75;
+    margin: 22px 0 0;
+    max-width: 710px;
+}
+
+.hero-actions,
+.closing-actions {
+    align-items: center;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-top: 28px;
+}
+
+.button {
+    align-items: center;
+    border-radius: 4px;
+    display: inline-flex;
+    font-size: 0.93rem;
+    font-weight: 750;
+    gap: 11px;
+    justify-content: center;
+    min-height: 48px;
+    padding: 0 18px;
+    text-decoration: none;
+    transition: background 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease;
+}
+
+.button:hover {
+    transform: translateY(-2px);
+}
+
+.button-primary {
+    background: var(--blue);
+    color: #ffffff;
+}
+
+.button-primary:hover {
+    background: #5684ed;
+}
+
+.button-quiet {
+    border: 1px solid rgba(216, 226, 241, 0.42);
+    color: #e6edfa;
+}
+
+.button-quiet:hover {
+    border-color: #ffffff;
+    color: #ffffff;
+}
+
+.button-outline {
+    border: 1px solid var(--line);
+    color: var(--ink);
+}
+
+.button-outline:hover {
+    border-color: var(--blue);
+    color: var(--blue-dark);
+}
+
+.hero-meta {
+    color: #8f9db3;
+    font-size: 0.84rem;
+    margin: 20px 0 0;
+}
+
+.meta-separator {
+    padding: 0 10px;
+}
+
+.hero-demo {
+    margin-top: clamp(36px, 5vw, 64px);
+}
+
+.demo-topline,
+.demo-caption {
+    align-items: center;
+    color: #99a8bf;
+    display: flex;
+    font-size: 0.78rem;
+    justify-content: space-between;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.demo-topline {
+    gap: 8px;
+    justify-content: flex-start;
+    margin-bottom: 14px;
+}
+
+.demo-dot {
+    background: var(--coral);
+    border-radius: 50%;
+    height: 7px;
+    width: 7px;
+}
+
+.hero-demo img {
+    background: #ffffff;
+    border: 1px solid rgba(220, 226, 235, 0.22);
+    border-radius: 4px;
+    box-shadow: var(--shadow);
+    display: block;
+    height: auto;
+    max-height: 67vh;
+    object-fit: cover;
+    object-position: center;
+    width: 100%;
+}
+
+.demo-caption {
+    margin-top: 13px;
+    text-transform: none;
+}
+
+.caption-arrow {
+    color: var(--coral);
+    font-size: 1.15rem;
+}
+
+.proof-strip {
+    background: #e7edf7;
+    border-bottom: 1px solid #d5ddea;
+    border-top: 1px solid #d5ddea;
+    color: #314463;
+    padding: 24px clamp(24px, 7vw, 112px);
+}
+
+.proof-strip p {
+    font-size: clamp(1rem, 1.8vw, 1.3rem);
+    font-weight: 650;
+    line-height: 1.45;
+    margin: 0 auto;
+    max-width: 1180px;
+}
+
+.section {
+    padding: clamp(76px, 10vw, 142px) clamp(24px, 5vw, 70px);
+}
+
+.section-heading {
+    max-width: 670px;
+}
+
+.section-heading .eyebrow,
+.evidence-copy .eyebrow,
+.privacy-band .eyebrow,
+.closing-section .eyebrow {
+    color: var(--blue-dark);
+}
+
+.section h2,
+.privacy-band h2,
+.closing-section h2 {
+    font-size: clamp(2rem, 4vw, 3.65rem);
+    letter-spacing: -0.045em;
+    line-height: 1.08;
+    margin: 0;
+}
+
+.section-heading > p:last-child,
+.evidence-copy > p:not(.eyebrow),
+.privacy-copy p {
+    color: var(--ink-muted);
+    font-size: 1.05rem;
+    line-height: 1.8;
+    margin: 22px 0 0;
+}
+
+.workflow-grid,
+.features-grid {
+    display: grid;
+    gap: 0;
+    grid-template-columns: repeat(3, 1fr);
+    margin-top: 70px;
+}
+
+.workflow-item {
+    border-left: 1px solid var(--line);
+    min-height: 190px;
+    padding: 0 34px;
+}
+
+.workflow-item:first-child {
+    border-left: 0;
+    padding-left: 0;
+}
+
+.step-number {
+    color: var(--coral);
+    font-size: 0.78rem;
+    font-weight: 800;
+    letter-spacing: 0.12em;
+}
+
+.workflow-item h3,
+.feature-item h3 {
+    font-size: 1.35rem;
+    letter-spacing: -0.02em;
+    margin: 22px 0 10px;
+}
+
+.workflow-item p,
+.feature-item p {
+    color: var(--ink-muted);
+    line-height: 1.75;
+    margin: 0;
+}
+
+.evidence-section {
+    align-items: center;
+    background: #eef3f8;
+    display: grid;
+    gap: clamp(42px, 8vw, 120px);
+    grid-template-columns: minmax(260px, 0.9fr) minmax(0, 1fr);
+    max-width: none;
+    padding-left: max(24px, calc((100% - 1040px) / 2));
+    padding-right: max(24px, calc((100% - 1040px) / 2));
+}
+
+.evidence-visual {
+    background: #ffffff;
+    border: 1px solid #d8e1ec;
+    box-shadow: 12px 17px 0 #d2dce8;
+    min-height: 350px;
+    padding: 42px 32px;
+    position: relative;
+}
+
+.paper-line {
+    background: #cfd8e5;
+    height: 9px;
+    margin-bottom: 17px;
+}
+
+.line-wide {
+    width: 88%;
+}
+
+.line-medium {
+    width: 68%;
+}
+
+.line-short {
+    width: 46%;
+}
+
+.evidence-highlight {
+    align-items: center;
+    background: #dfeaff;
+    border-left: 4px solid var(--blue);
+    color: #315ebc;
+    display: flex;
+    font-size: 0.8rem;
+    font-weight: 750;
+    gap: 8px;
+    margin: 26px 0;
+    padding: 14px 13px;
+}
+
+.evidence-pin {
+    font-size: 1.25rem;
+}
+
+.evidence-note {
+    align-items: center;
+    background: #fff0e8;
+    bottom: 35px;
+    color: #9d593f;
+    display: flex;
+    font-size: 0.78rem;
+    font-weight: 750;
+    gap: 9px;
+    padding: 11px 13px;
+    position: absolute;
+    right: 24px;
+}
+
+.note-mark {
+    background: var(--coral);
+    border-radius: 50%;
+    height: 8px;
+    width: 8px;
+}
+
+.evidence-copy {
+    max-width: 520px;
+}
+
+.feature-list {
+    list-style: none;
+    margin: 30px 0 0;
+    padding: 0;
+}
+
+.feature-list li {
+    align-items: center;
+    border-top: 1px solid var(--line);
+    display: flex;
+    gap: 14px;
+    padding: 14px 0;
+}
+
+.feature-list li:last-child {
+    border-bottom: 1px solid var(--line);
+}
+
+.list-marker {
+    color: var(--blue-dark);
+    flex: 0 0 22px;
+    font-weight: 800;
+    text-align: center;
+}
+
+.compact-heading {
+    max-width: 800px;
+}
+
+.features-grid {
+    border-top: 1px solid var(--line);
+    grid-template-columns: repeat(4, 1fr);
+    margin-top: 52px;
+}
+
+.feature-item {
+    border-left: 1px solid var(--line);
+    min-height: 250px;
+    padding: 30px 24px 0;
+}
+
+.feature-item:first-child {
+    border-left: 0;
+    padding-left: 0;
+}
+
+.feature-icon {
+    align-items: center;
+    border-radius: 4px;
+    display: flex;
+    font-size: 1.15rem;
+    font-weight: 850;
+    height: 38px;
+    justify-content: center;
+    width: 38px;
+}
+
+.icon-blue {
+    background: #dfebff;
+    color: var(--blue-dark);
+}
+
+.icon-coral {
+    background: #fff0e8;
+    color: #ad6247;
+}
+
+.icon-teal {
+    background: #ddf2ef;
+    color: var(--teal);
+}
+
+.icon-gold {
+    background: #fff2d9;
+    color: var(--gold);
+}
+
+.privacy-band {
+    align-items: start;
+    background: #15233b;
+    color: #f8fbff;
+    display: grid;
+    gap: 60px;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
+    max-width: none;
+    padding: clamp(60px, 8vw, 100px) max(24px, calc((100% - 1040px) / 2));
+}
+
+.privacy-band .eyebrow {
+    color: #85a9ff;
+}
+
+.privacy-copy p {
+    color: #bbc7d8;
+    margin-top: 0;
+}
+
+.text-link {
+    align-items: center;
+    color: #ffffff;
+    display: inline-flex;
+    font-weight: 750;
+    gap: 10px;
+    margin-top: 22px;
+    text-decoration-color: rgba(255, 255, 255, 0.45);
+    text-underline-offset: 5px;
+}
+
+.closing-section {
+    padding: clamp(82px, 11vw, 150px) clamp(24px, 5vw, 70px);
+    text-align: center;
+}
+
+.closing-section h2 {
+    margin: 0 auto;
+    max-width: 730px;
+}
+
+.closing-section .eyebrow {
+    margin-bottom: 20px;
+}
+
+.closing-actions {
+    justify-content: center;
+}
+
+.closing-meta {
+    color: var(--ink-muted);
+    font-size: 0.83rem;
+    margin: 22px 0 0;
+}
+
+.site-footer {
+    align-items: center;
+    border-top: 1px solid var(--line);
+    color: var(--ink-muted);
+    display: flex;
+    font-size: 0.8rem;
+    gap: 18px;
+    justify-content: space-between;
+    padding: 24px clamp(24px, 5vw, 70px) 32px;
+}
+
+.site-footer a {
+    color: var(--ink);
+    font-weight: 750;
+    text-decoration: none;
+}
+
+@media (max-width: 800px) {
+    .site-header {
+        min-height: 62px;
+        padding: 0 18px;
+    }
+
+    .site-nav {
+        gap: 11px;
+    }
+
+    .site-nav a:not(:last-of-type) {
+        display: none;
+    }
+
+    .hero h1 {
+        font-size: clamp(2.5rem, 12vw, 4.2rem);
+    }
+
+    .hero-demo img {
+        min-height: 235px;
+        object-fit: cover;
+        object-position: left center;
+    }
+
+    .workflow-grid,
+    .features-grid,
+    .evidence-section,
+    .privacy-band {
+        grid-template-columns: 1fr;
+    }
+
+    .workflow-grid {
+        gap: 0;
+        margin-top: 48px;
+    }
+
+    .workflow-item,
+    .feature-item {
+        border-left: 0;
+        border-top: 1px solid var(--line);
+        min-height: 0;
+        padding: 28px 0;
+    }
+
+    .workflow-item:first-child,
+    .feature-item:first-child {
+        border-top: 0;
+        padding-left: 0;
+    }
+
+    .features-grid {
+        margin-top: 32px;
+    }
+
+    .evidence-section {
+        gap: 52px;
+    }
+
+    .evidence-visual {
+        min-height: 300px;
+    }
+
+    .privacy-band {
+        gap: 28px;
+    }
+
+    .site-footer {
+        align-items: flex-start;
+        flex-direction: column;
+        gap: 8px;
+    }
+}
+
+@media (max-width: 480px) {
+    .hero-actions,
+    .closing-actions {
+        align-items: stretch;
+        flex-direction: column;
+    }
+
+    .button {
+        width: 100%;
+    }
+
+    .hero-demo img {
+        min-height: 190px;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html {
+        scroll-behavior: auto;
+    }
+
+    .button {
+        transition: none;
+    }
+}

--- a/docs/site.js
+++ b/docs/site.js
@@ -1,0 +1,136 @@
+const messages = {
+    zh: {
+        'nav.workflow': '工作流',
+        'nav.evidence': '证据链',
+        'nav.privacy': '隐私',
+        'hero.eyebrow': 'ZOTERO READING LAYER',
+        'hero.title': '把复杂论文重排成好读的正文，同时保留每条证据回到 PDF 的路径。',
+        'hero.lede': 'Mktero 是一个面向 Zotero 的来源关联重排阅读器。阅读双栏、公式和表格密集的论文，在 Markdown 中标注，再回到原始 PDF 核对。',
+        'hero.download': '下载最新版本',
+        'hero.beta': '加入种子用户',
+        'hero.support': '支持 Zotero 7、8 和 9',
+        'hero.openSource': 'MIT 开源',
+        'hero.demoLabel': '从 Zotero PDF 到可核验阅读',
+        'hero.demoCaption': '重排阅读 · Zotero 标注 · PDF 来源跳转',
+        proof: '不是另一个 Markdown 编辑器。Mktero 让 PDF 成为事实源，让阅读、标注和摘录保持可核验。',
+        'workflow.eyebrow': 'THE READING LOOP',
+        'workflow.title': '一篇论文，三步进入你的阅读工作流。',
+        'workflow.lede': 'Mktero 把转换结果留在 Zotero 的阅读上下文里，不迫使你在 PDF、笔记和浏览器之间来回切换。',
+        'workflow.one.title': '打开',
+        'workflow.one.body': '从 PDF 阅读器工具栏或文库右键打开。Mktero 使用 MinerU 解析正文、公式、表格、图片和引用。',
+        'workflow.two.title': '阅读与标注',
+        'workflow.two.body': '在连续、只读的 Markdown 视图中搜索、浏览目录、预览引用和图表，并直接创建 Zotero 标注。',
+        'workflow.three.title': '核对与复用',
+        'workflow.three.body': '点击来源回到 PDF 原位，或复制带论文标题、物理页码和 Zotero 回链的摘录。',
+        'evidence.eyebrow': 'READ WITH PROOF',
+        'evidence.title': '每一次摘录，都有回去的路。',
+        'evidence.lede': 'MinerU 的内容块与 PDF 页码、区域坐标建立关联。Mktero 只在匹配可靠时显示跳转，宁可少一个按钮，也不猜测原文位置。',
+        'evidence.pin': '第 4 页 · 来源块',
+        'evidence.note': '同步到 Zotero 的高亮',
+        'evidence.itemOne': '正文、公式、表格和图表都可以回到 PDF 来源',
+        'evidence.itemTwo': 'Markdown 与 Zotero PDF 标注保持同步',
+        'evidence.itemThree': '复制摘录时保留页码与 Zotero 回链',
+        'features.eyebrow': 'MADE FOR PAPERS',
+        'features.title': '为真正难读的论文而做。',
+        'features.one.title': '连续正文',
+        'features.one.body': '把双栏布局、OCR 断行、公式和表格整理成适合连续阅读的视图。',
+        'features.two.title': '学术结构',
+        'features.two.body': '目录、引用预览、图表引用、图片放大和 KaTeX 公式都保留在阅读上下文中。',
+        'features.three.title': '来源意识',
+        'features.three.body': '不把 Markdown 当作新的事实源。PDF 仍是原文，Mktero 负责让它更容易读和核对。',
+        'features.four.title': '本地缓存',
+        'features.four.body': '相同 PDF 可从本机缓存打开，避免每次重新上传和解析。',
+        'privacy.eyebrow': 'KNOW WHERE YOUR PAPER GOES',
+        'privacy.title': '数据边界清楚，选择留给你。',
+        'privacy.body': '首次转换或缓存未命中时，完整 PDF 会上传到 MinerU。API Token、Markdown、图片和标注缓存保存在本机 Zotero 配置文件中，未加密且不会通过 Zotero 同步。',
+        'privacy.link': '阅读完整隐私说明',
+        'closing.eyebrow': 'START WITH ONE PAPER',
+        'closing.title': '让下一篇论文更容易读懂，也更容易核对。',
+        'closing.download': '下载 Mktero',
+        'closing.source': '查看源代码',
+        'closing.meta': '需要 MinerU API Token · 支持 Zotero 7–9 · MIT License',
+        footer: '一个让学术阅读更可核验的 Zotero 插件。',
+    },
+    en: {
+        'nav.workflow': 'Workflow',
+        'nav.evidence': 'Evidence',
+        'nav.privacy': 'Privacy',
+        'hero.eyebrow': 'ZOTERO READING LAYER',
+        'hero.title': 'Read complex papers as clean text without losing the path back to the PDF.',
+        'hero.lede': 'Mktero is a source-linked reflow reader for Zotero. Read papers with dense layouts, formulas, and tables in Markdown, annotate them, and verify every passage in the original PDF.',
+        'hero.download': 'Download latest release',
+        'hero.beta': 'Join the seed cohort',
+        'hero.support': 'Supports Zotero 7, 8, and 9',
+        'hero.openSource': 'MIT licensed',
+        'hero.demoLabel': 'From a Zotero PDF to verifiable reading',
+        'hero.demoCaption': 'Reflowed reading · Zotero annotations · PDF source navigation',
+        proof: 'Not another Markdown editor. Mktero keeps the PDF as the source of truth while making reading, annotation, and reuse verifiable.',
+        'workflow.eyebrow': 'THE READING LOOP',
+        'workflow.title': 'One paper, three steps into your reading workflow.',
+        'workflow.lede': 'Mktero keeps the parsed result in Zotero, so you can move through reading, annotation, and verification without losing context.',
+        'workflow.one.title': 'Open',
+        'workflow.one.body': 'Open from the PDF reader toolbar or the library context menu. MinerU extracts text, formulas, tables, figures, and references.',
+        'workflow.two.title': 'Read and annotate',
+        'workflow.two.body': 'Search a continuous, read-only Markdown view, browse the outline, preview references and figures, and create Zotero annotations.',
+        'workflow.three.title': 'Verify and reuse',
+        'workflow.three.body': 'Jump back to the source PDF or copy a passage with its paper title, physical page, and Zotero link.',
+        'evidence.eyebrow': 'READ WITH PROOF',
+        'evidence.title': 'Every excerpt has a way back.',
+        'evidence.lede': 'MinerU content blocks are linked to PDF pages and region coordinates. Mktero only shows navigation when the match is reliable; it does not guess.',
+        'evidence.pin': 'Page 4 · source block',
+        'evidence.note': 'Highlight synced to Zotero',
+        'evidence.itemOne': 'Return to the PDF source for text, formulas, tables, and figures',
+        'evidence.itemTwo': 'Keep Markdown annotations in sync with Zotero PDF annotations',
+        'evidence.itemThree': 'Copy excerpts with page numbers and Zotero links',
+        'features.eyebrow': 'MADE FOR PAPERS',
+        'features.title': 'Built for papers that are hard to read.',
+        'features.one.title': 'Continuous text',
+        'features.one.body': 'Turn columns, OCR line breaks, formulas, and tables into a view made for focused reading.',
+        'features.two.title': 'Academic structure',
+        'features.two.body': 'Keep outlines, citation previews, figure references, image zoom, and KaTeX formulas in context.',
+        'features.three.title': 'Source-aware by design',
+        'features.three.body': 'Markdown is a reading surface, not a replacement source. The PDF remains the paper; Mktero makes it easier to read and check.',
+        'features.four.title': 'Local cache',
+        'features.four.body': 'Open unchanged PDFs from the local cache instead of uploading and parsing them again.',
+        'privacy.eyebrow': 'KNOW WHERE YOUR PAPER GOES',
+        'privacy.title': 'Clear data boundaries. Your choice.',
+        'privacy.body': 'On the first conversion or a cache miss, the complete PDF is uploaded to MinerU. API tokens, Markdown, images, and annotation caches stay unencrypted in the local Zotero profile and are not synced by Zotero.',
+        'privacy.link': 'Read the full privacy notes',
+        'closing.eyebrow': 'START WITH ONE PAPER',
+        'closing.title': 'Make your next paper easier to understand and easier to verify.',
+        'closing.download': 'Download Mktero',
+        'closing.source': 'View source',
+        'closing.meta': 'MinerU API Token required · Zotero 7–9 · MIT License',
+        footer: 'A Zotero plugin for more verifiable scholarly reading.',
+    },
+};
+
+const languageButton = document.querySelector('[data-language-toggle]');
+const languageNames = { zh: 'EN', en: '中' };
+let language = document.documentElement.lang === 'en' ? 'en' : 'zh';
+
+function translatePage() {
+    document.documentElement.lang = language === 'en' ? 'en' : 'zh-CN';
+    for (const element of document.querySelectorAll('[data-i18n]')) {
+        const message = messages[language][element.dataset.i18n];
+        if (message) element.textContent = message;
+    }
+    languageButton.textContent = languageNames[language];
+    languageButton.setAttribute(
+        'aria-label',
+        language === 'en' ? '切换到简体中文' : 'Switch to English'
+    );
+    document.title = language === 'en'
+        ? 'Mktero | Source-linked reading for Zotero'
+        : 'Mktero | Zotero 的来源关联阅读器';
+    localStorage.setItem('mktero-language', language);
+}
+
+const savedLanguage = localStorage.getItem('mktero-language');
+if (savedLanguage === 'en' || savedLanguage === 'zh') language = savedLanguage;
+languageButton.addEventListener('click', () => {
+    language = language === 'en' ? 'zh' : 'en';
+    translatePage();
+});
+document.querySelector('[data-current-year]').textContent = new Date().getFullYear();
+translatePage();


### PR DESCRIPTION
## Summary
- Add a bilingual GitHub Pages landing page under `docs/`.
- Explain source-linked reflow reading, Zotero workflow, evidence navigation, privacy boundaries, and MinerU processing.
- Add responsive styling, Chinese/English toggle, download CTA, and seed-user CTA.
- Link the landing page and release assets from `README.md`.

## Verification
- `node --check docs/site.js`
- `npm run check`
- `npm test` (600 passed)
- `npm run build`
- Browser preview checked at desktop and 390px mobile widths with no horizontal overflow or console errors.