### PR TITLE
fix: preserve full landing page demo gif

### DIFF
--- a/docs/site.css
+++ b/docs/site.css
@@ -265,9 +265,6 @@ a {
     box-shadow: var(--shadow);
     display: block;
     height: auto;
-    max-height: 67vh;
-    object-fit: cover;
-    object-position: center;
     width: 100%;
 }
 
@@ -618,9 +615,7 @@ a {
     }
 
     .hero-demo img {
-        min-height: 235px;
-        object-fit: cover;
-        object-position: left center;
+        min-height: 0;
     }
 
     .workflow-grid,
@@ -684,7 +679,7 @@ a {
     }
 
     .hero-demo img {
-        min-height: 190px;
+        min-height: 0;
     }
 }
 


### PR DESCRIPTION
## Summary
- Prevent the landing page demo GIF from being cropped vertically.
- Preserve the GIF aspect ratio on desktop and mobile layouts.

## Verification
- Browser-checked desktop and 390px mobile layouts.
- `git diff --check` passed.