### PR TITLE
Fix Markdown notes panel resizing during scrolling

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,10 @@ Zotero 本地 PDF -> MinerU VLM 解析 -> full.md、content_list.json 与图片 
   将解析图片作为 Note 的嵌入图片附件保存，并将原始
   source.md、source-map.json 作为当前文献条目的附件保存，并通过 Zotero relation 关联到
   专用 Note。识别 manifest 保存在 Zotero 会保留的标准链接中。这些内容由 Zotero 正常
-  同步；公式会保存为 Zotero 原生数学节点，双击 Note 时由 Zotero 自己渲染。其他 Zotero
-  Note 不会被扫描或修改。没有所属文献条目的独立 PDF 不能保存快照。
+  同步；公式会保存为 Zotero 原生数学节点，双击 Note 时由 Zotero 自己渲染。来源映射
+  异常时仍会保存 Markdown 和 HTML 快照，但该快照不能跳转回 PDF 原文。保存成功或失败
+  的提示会短暂显示并自动消失，关闭标签页时也会清理提示状态。其他 Zotero Note 不会被
+  扫描或修改。没有所属文献条目的独立 PDF 不能保存快照。
 - 在安装 Mktero 的桌面端，右键 Mktero 专用 Note 会优先读取匹配的本地缓存或同步的
   source.md，因此继续使用 Markdown 阅读器、来源跳转和标注功能；如果源附件未下载或
   不可用，则显示同步到 Note 中的 HTML 快照。没有安装 Mktero 的 Zotero 客户端可以直接
@@ -77,7 +79,9 @@ Zotero 本地 PDF -> MinerU VLM 解析 -> full.md、content_list.json 与图片 
 - 在 Markdown 正文和渲染后的表格、图题等内容中显示 Zotero PDF 高亮与下划线标注，
   保留标注颜色；匹配时会分别处理普通 Markdown 转义标点与行内公式中的 LaTeX 命令，
   并兼容 PDF 与 MinerU 之间的智能引号、连字符、数字引用、句末脚注上标、商标上标、
-  统计运算符空格以及常见温度和正负号 LaTeX 格式差异；鼠标在划词上短暂停留或用键盘
+  统计运算符空格、度数单位周围的 PDF 文本层空格、温度单位的 `\\mathrm` LaTeX 包装以及
+  常见温度和正负号 LaTeX 格式差异；
+  鼠标在划词上短暂停留或用键盘
   聚焦时可更改颜色或删除对应 Zotero 标注，点击划词可新增或编辑评论；带评论的标注会在
   起始左上角显示笔记图标，点击或用键盘激活图标可继续修改评论。
 - 在普通 Markdown 正文中拖动划词后显示紧凑操作条，可选择颜色立即保存 Markdown 高亮，

--- a/src/markdown/pdf-annotation-text.js
+++ b/src/markdown/pdf-annotation-text.js
@@ -13,6 +13,8 @@ const SENTENCE_END = /[.!?。！？]/u;
 const RELATIONAL_OPERATOR_PATTERN = /([\p{L}\p{N})\]}])(\s*)(<=|>=|!=|[=<>≤≥≠])(\s*)(?=[\p{L}\p{N}([{\-+−±.])/gu;
 const SIGNED_NUMBER_WHITESPACE_PATTERN = /[+\-−±](\s+)(?=\d)/gu;
 const DEGREE_SYMBOL_WHITESPACE_PATTERN = /([\p{N})\]}])(\s+)(?=°)/gu;
+const DEGREE_SYMBOL_UNIT_WHITESPACE_PATTERN = /°(\s+)(?=\p{L})/gu;
+const LATEX_TEXT_UNIT_PATTERN = /(?<!\\)\\mathrm\{([A-Za-z]{1,32})\}/gu;
 const LATEX_SYMBOL_REPLACEMENTS = [
     { pattern: /(?<![\\;])(?:\\;)?\^\{\\circ\}/gu, text: '°' },
     { pattern: /(?<!\\)\\pm(?![A-Za-z])/gu, text: '±' },
@@ -226,6 +228,18 @@ function markLatexSymbols(text, ignoredOffsets, replacements) {
             );
         }
     }
+    for (const match of text.matchAll(LATEX_TEXT_UNIT_PATTERN)) {
+        replacements.set(match.index, {
+            from: match.index,
+            to: match.index + match[0].length,
+            text: match[1],
+        });
+        markOffsetRange(
+            ignoredOffsets,
+            match.index + 1,
+            match[0].length - 1
+        );
+    }
 }
 
 function markMathematicalWhitespace(text, ignoredOffsets) {
@@ -254,6 +268,15 @@ function markMathematicalWhitespace(text, ignoredOffsets) {
             ignoredOffsets,
             match.index + match[1].length,
             match[2].length
+        );
+    }
+    for (const match of text.matchAll(
+        DEGREE_SYMBOL_UNIT_WHITESPACE_PATTERN
+    )) {
+        markOffsetRange(
+            ignoredOffsets,
+            match.index + 1,
+            match[1].length
         );
     }
 }

--- a/src/platform/zotero-saved-markdown-store.js
+++ b/src/platform/zotero-saved-markdown-store.js
@@ -647,11 +647,7 @@ export class ZoteroSavedMarkdownStore {
 
     async #prepareSnapshot({ markdown, assets, assetBasePath, sourceMap }) {
         const normalizedAssets = normalizeAssets(assets);
-        const sourceMapJSON = JSON.stringify(sourceMap);
-        if (new TextEncoder().encode(sourceMapJSON).length > MAX_SOURCE_MAP_BYTES) {
-            throw new Error('Saved Markdown source map exceeds the size limit');
-        }
-        validateSourceMap(sourceMap, markdown.length);
+        const sourceMapJSON = serializeSourceMapJSON(sourceMap, markdown.length);
         return {
             markdown,
             normalizedAssets,
@@ -1042,10 +1038,18 @@ function parseSourceMap(sourceMapJSON, markdownLength) {
     return sourceMap;
 }
 
-function validateSourceMap(sourceMap, markdownLength) {
-    if (sourceMap.length > MAX_SOURCE_MAP_ENTRIES
-        || sourceMap.some(entry => !isValidSourceMapEntry(entry, markdownLength))) {
-        throw new Error('Saved Markdown source map is invalid');
+function serializeSourceMapJSON(sourceMap, markdownLength) {
+    try {
+        const validEntries = sourceMap.length > MAX_SOURCE_MAP_ENTRIES
+            ? []
+            : sourceMap.filter(entry => isValidSourceMapEntry(entry, markdownLength));
+        const serialized = JSON.stringify(validEntries);
+        return new TextEncoder().encode(serialized).length > MAX_SOURCE_MAP_BYTES
+            ? '[]'
+            : serialized;
+    }
+    catch {
+        return '[]';
     }
 }
 

--- a/src/ui/markdown-window.js
+++ b/src/ui/markdown-window.js
@@ -23,6 +23,7 @@ const XHTML_NAMESPACE = 'http://www.w3.org/1999/xhtml';
 const BUNDLED_MARKDOWN_STYLES = typeof __MKTERO_MARKDOWN_STYLES__ === 'string'
     ? __MKTERO_MARKDOWN_STYLES__
     : null;
+const DOCUMENT_ACTION_STATUS_TIMEOUT_MS = 5_000;
 const SIDE_PANEL_KEYBOARD_STEP = 16;
 const RESPONSIVE_SIDE_PANEL_BREAKPOINTS = Object.freeze({
     outline: 820,
@@ -110,6 +111,7 @@ class MarkdownTabView {
         this.renderedSnapshotAssets = undefined;
         this.snapshotURLs = new Map();
         this.documentActionBusy = null;
+        this.actionStatusTimer = null;
         this.documentActionsOpen = false;
         this.activeNavigationOffset = 0;
         this.listeners = [];
@@ -255,6 +257,7 @@ class MarkdownTabView {
     }
 
     destroy() {
+        this.clearDocumentActionStatus();
         for (const { element, type, listener } of this.listeners) {
             element.removeEventListener(type, listener);
         }
@@ -891,10 +894,7 @@ class MarkdownTabView {
         }
         this.documentActionBusy = kind;
         if (kind === 'saveSnapshot') {
-            this.elements.actionStatus.textContent = this.t(
-                'viewer.snapshotSaving'
-            );
-            this.elements.actionStatus.hidden = false;
+            this.setDocumentActionStatus('viewer.snapshotSaving');
         }
         this.setDocumentActionsOpen(false);
         this.syncDocumentActions(
@@ -907,6 +907,12 @@ class MarkdownTabView {
         }
         catch (error) {
             this.zotero?.logError?.(error);
+            if (kind === 'saveSnapshot') {
+                this.setDocumentActionStatus(
+                    'viewer.snapshotSaveFailed',
+                    { dismissAfter: true }
+                );
+            }
             this.documentActionBusy = null;
             this.syncDocumentActions(
                 this.model,
@@ -917,15 +923,18 @@ class MarkdownTabView {
         Promise.resolve(operation)
             .then(() => {
                 if (kind === 'saveSnapshot') {
-                    this.elements.actionStatus.textContent
-                        = this.t('viewer.snapshotSaved');
+                    this.setDocumentActionStatus(
+                        'viewer.snapshotSaved',
+                        { dismissAfter: true }
+                    );
                 }
             })
             .catch(error => {
                 this.zotero?.logError?.(error);
                 if (kind === 'saveSnapshot') {
-                    this.elements.actionStatus.textContent = this.t(
-                        'viewer.snapshotSaveFailed'
+                    this.setDocumentActionStatus(
+                        'viewer.snapshotSaveFailed',
+                        { dismissAfter: true }
                     );
                 }
             })
@@ -936,6 +945,30 @@ class MarkdownTabView {
                     createLoadingPresentation(this.model, this.t)
                 );
             });
+    }
+
+    setDocumentActionStatus(key, { dismissAfter = false } = {}) {
+        this.clearDocumentActionStatus();
+        this.elements.actionStatus.textContent = this.t(key);
+        this.elements.actionStatus.hidden = false;
+        if (!dismissAfter || typeof this.ownerWindow.setTimeout !== 'function') {
+            return;
+        }
+        this.actionStatusTimer = this.ownerWindow.setTimeout(() => {
+            this.actionStatusTimer = null;
+            this.elements.actionStatus.textContent = '';
+            this.elements.actionStatus.hidden = true;
+        }, DOCUMENT_ACTION_STATUS_TIMEOUT_MS);
+    }
+
+    clearDocumentActionStatus() {
+        if (this.actionStatusTimer !== null) {
+            this.ownerWindow.clearTimeout?.(this.actionStatusTimer);
+            this.actionStatusTimer = null;
+        }
+        if (!this.elements?.actionStatus) return;
+        this.elements.actionStatus.textContent = '';
+        this.elements.actionStatus.hidden = true;
     }
 
     runNoteButtonAction(button, action) {

--- a/src/ui/markdown-window.js
+++ b/src/ui/markdown-window.js
@@ -259,8 +259,8 @@ class MarkdownTabView {
 
     destroy() {
         this.clearDocumentActionStatus();
-        for (const { element, type, listener } of this.listeners) {
-            element.removeEventListener(type, listener);
+        for (const { element, type, listener, options } of this.listeners) {
+            element.removeEventListener(type, listener, options);
         }
         this.listeners = [];
         this.editor?.destroy();
@@ -903,6 +903,30 @@ class MarkdownTabView {
             cancelSidePanelResizes,
             { capture: true }
         );
+        this.listen(
+            this.elements.workspace,
+            'scroll',
+            cancelSidePanelResizes,
+            { capture: true }
+        );
+        this.listen(
+            this.elements.workspace,
+            'wheel',
+            cancelSidePanelResizes,
+            { capture: true }
+        );
+        this.listen(
+            this.document,
+            'scroll',
+            cancelSidePanelResizes,
+            { capture: true }
+        );
+        this.listen(
+            this.document,
+            'wheel',
+            cancelSidePanelResizes,
+            { capture: true }
+        );
         this.syncResponsiveSidePanels();
     }
 
@@ -1167,6 +1191,15 @@ class MarkdownTabView {
     resizeSidePanel(name, event) {
         const panel = this.sidePanels[name];
         if (!panel.resize || !Number.isFinite(event.clientX)) return;
+        if (Number.isFinite(event.buttons) && event.buttons !== 1) {
+            this.cancelSidePanelResize(name);
+            return;
+        }
+        if (panel.resize.pointerStartY !== null
+            && !Number.isFinite(event.clientY)) {
+            this.cancelSidePanelResize(name);
+            return;
+        }
         const deltaX = event.clientX - panel.resize.pointerStartX;
         const deltaY = panel.resize.pointerStartY === null
             || !Number.isFinite(event.clientY)

--- a/src/ui/markdown-window.js
+++ b/src/ui/markdown-window.js
@@ -25,6 +25,7 @@ const BUNDLED_MARKDOWN_STYLES = typeof __MKTERO_MARKDOWN_STYLES__ === 'string'
     : null;
 const DOCUMENT_ACTION_STATUS_TIMEOUT_MS = 5_000;
 const SIDE_PANEL_KEYBOARD_STEP = 16;
+const SIDE_PANEL_RESIZE_ACTIVATION_DISTANCE = 4;
 const RESPONSIVE_SIDE_PANEL_BREAKPOINTS = Object.freeze({
     outline: 820,
     notes: 1120,
@@ -880,6 +881,28 @@ class MarkdownTabView {
             this.finishSidePanelResize('outline');
             this.finishSidePanelResize('notes');
         });
+        const cancelSidePanelResizes = () => {
+            this.cancelSidePanelResize('outline');
+            this.cancelSidePanelResize('notes');
+        };
+        const editorScroller = this.elements.editorHost.querySelector(
+            '.cm-scroller'
+        );
+        if (editorScroller) {
+            this.listen(editorScroller, 'scroll', cancelSidePanelResizes);
+        }
+        this.listen(
+            this.elements.editorHost,
+            'scroll',
+            cancelSidePanelResizes,
+            { capture: true }
+        );
+        this.listen(
+            this.elements.editorHost,
+            'wheel',
+            cancelSidePanelResizes,
+            { capture: true }
+        );
         this.syncResponsiveSidePanels();
     }
 
@@ -1003,9 +1026,9 @@ class MarkdownTabView {
         });
     }
 
-    listen(element, type, listener) {
-        element.addEventListener(type, listener);
-        this.listeners.push({ element, type, listener });
+    listen(element, type, listener, options) {
+        element.addEventListener(type, listener, options);
+        this.listeners.push({ element, type, listener, options });
     }
 
     syncContentVisibility(visible) {
@@ -1131,17 +1154,43 @@ class MarkdownTabView {
             || this.elements.workspace.hidden) {
             return;
         }
-        event.preventDefault();
         panel.resize = {
             pointerStartX: event.clientX,
+            pointerStartY: Number.isFinite(event.clientY)
+                ? event.clientY
+                : null,
             widthAtStart: panel.width,
+            active: false,
         };
-        this.elements.workspace.classList.add(panel.resizeClass);
     }
 
     resizeSidePanel(name, event) {
         const panel = this.sidePanels[name];
         if (!panel.resize || !Number.isFinite(event.clientX)) return;
+        const deltaX = event.clientX - panel.resize.pointerStartX;
+        const deltaY = panel.resize.pointerStartY === null
+            || !Number.isFinite(event.clientY)
+            ? 0
+            : event.clientY - panel.resize.pointerStartY;
+        const horizontalDistance = Math.abs(deltaX);
+        const verticalDistance = Math.abs(deltaY);
+        if (panel.resize.pointerStartY !== null
+            && horizontalDistance <= verticalDistance) {
+            if (panel.resize.active) {
+                this.setSidePanelWidth(name, panel.resize.widthAtStart);
+            }
+            this.finishSidePanelResize(name);
+            return;
+        }
+        if (!panel.resize.active) {
+            if (Math.max(horizontalDistance, verticalDistance)
+                < SIDE_PANEL_RESIZE_ACTIVATION_DISTANCE) {
+                return;
+            }
+            panel.resize.active = true;
+            event.preventDefault();
+            this.elements.workspace.classList.add(panel.resizeClass);
+        }
         this.setSidePanelWidth(
             name,
             panel.resize.widthAtStart
@@ -1155,6 +1204,14 @@ class MarkdownTabView {
         if (!panel.resize) return;
         panel.resize = null;
         this.elements.workspace.classList.remove(panel.resizeClass);
+    }
+
+    cancelSidePanelResize(name) {
+        const panel = this.sidePanels[name];
+        if (panel.resize?.active) {
+            this.setSidePanelWidth(name, panel.resize.widthAtStart);
+        }
+        this.finishSidePanelResize(name);
     }
 
     setSidePanelWidth(name, width) {

--- a/test/markdown-editor-styles.test.js
+++ b/test/markdown-editor-styles.test.js
@@ -187,6 +187,10 @@ test('lays out a responsive scrollable outline beside the editor', () => {
     assert.match(resizer, /inset:\s*0/);
     assert.match(resizer, /cursor:\s*col-resize/);
 
+    const notesResizer = ruleBody('.markdown-notes-resizer');
+    assert.match(notesResizer, /inset-inline-start:\s*4px/);
+    assert.match(notesResizer, /inset-inline-end:\s*0/);
+
     const resizing = ruleBody('.markdown-workspace.is-resizing-outline');
     assert.match(resizing, /user-select:\s*none/);
 

--- a/test/markdown-window.test.js
+++ b/test/markdown-window.test.js
@@ -380,6 +380,80 @@ test('opens the document action menu and reports snapshot save state', async () 
     view.destroy();
 });
 
+test('clears a failed snapshot save status after reporting the error', async () => {
+    let rejectSave;
+    const model = createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: '# Paper',
+        sourceKind: 'markdown',
+        onSaveSnapshot: () => new Promise((resolve, reject) => {
+            rejectSave = reject;
+        }),
+    });
+    const { view, shadow } = createView(model);
+    const timers = [];
+    const clearCalls = [];
+    view.ownerWindow.setTimeout = (callback, delay) => {
+        const timer = { callback, delay };
+        timers.push(timer);
+        return timer;
+    };
+    view.ownerWindow.clearTimeout = timer => clearCalls.push(timer);
+
+    const toggle = shadow.querySelector('#mktero-document-actions');
+    const save = shadow.querySelector('#mktero-save-snapshot');
+    toggle.click();
+    save.click();
+    rejectSave(new Error('snapshot save failed'));
+    await new Promise(resolve => setImmediate(resolve));
+
+    const status = shadow.querySelector('.markdown-reader-action-status');
+    assert.equal(status.hidden, false);
+    assert.equal(status.textContent, 'The Zotero snapshot could not be saved.');
+    assert.equal(timers.length, 1);
+    assert.equal(timers[0].delay > 0, true);
+
+    timers[0].callback();
+    assert.equal(status.hidden, true);
+    assert.equal(status.textContent, '');
+
+    view.destroy();
+    assert.deepEqual(clearCalls, []);
+});
+
+test('cancels a pending snapshot status dismissal when the view is destroyed', async () => {
+    let rejectSave;
+    const model = createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: '# Paper',
+        sourceKind: 'markdown',
+        onSaveSnapshot: () => new Promise((resolve, reject) => {
+            rejectSave = reject;
+        }),
+    });
+    const { view, shadow } = createView(model);
+    const timers = [];
+    const clearCalls = [];
+    view.ownerWindow.setTimeout = (callback, delay) => {
+        const timer = { callback, delay };
+        timers.push(timer);
+        return timer;
+    };
+    view.ownerWindow.clearTimeout = timer => clearCalls.push(timer);
+
+    shadow.querySelector('#mktero-document-actions').click();
+    shadow.querySelector('#mktero-save-snapshot').click();
+    rejectSave(new Error('snapshot save failed'));
+    await new Promise(resolve => setImmediate(resolve));
+
+    view.destroy();
+
+    assert.equal(timers.length, 1);
+    assert.deepEqual(clearCalls, [timers[0]]);
+});
+
 test('renders a saved HTML snapshot without exposing PDF actions or editing controls', () => {
     const { view, shadow } = createView(createModel({
         status: 'ready',

--- a/test/markdown-window.test.js
+++ b/test/markdown-window.test.js
@@ -59,11 +59,14 @@ function createView(model = createModel(), zotero = {}, options = {}) {
 function createTestInlineEditor({ document, parent, initialMarkdown }) {
     const editor = document.createElement('div');
     editor.className = 'cm-editor';
+    const scroller = document.createElement('div');
+    scroller.className = 'cm-scroller';
     const content = document.createElement('div');
     content.className = 'cm-content';
     content.setAttribute('contenteditable', 'false');
     content.textContent = initialMarkdown;
-    editor.appendChild(content);
+    scroller.appendChild(content);
+    editor.appendChild(scroller);
     parent.appendChild(editor);
     return {
         getMarkdown: () => content.textContent,
@@ -79,7 +82,7 @@ function createTestInlineEditor({ document, parent, initialMarkdown }) {
     };
 }
 
-function dispatchMouseEvent(target, type, clientX) {
+function dispatchMouseEvent(target, type, clientX, clientY = 0) {
     const ownerWindow = target.ownerDocument?.defaultView || target;
     const event = new ownerWindow.Event(type, {
         bubbles: true,
@@ -88,6 +91,7 @@ function dispatchMouseEvent(target, type, clientX) {
     Object.defineProperties(event, {
         button: { value: 0 },
         clientX: { value: clientX },
+        clientY: { value: clientY },
     });
     target.dispatchEvent(event);
 }
@@ -932,6 +936,93 @@ test('resizes and toggles PDF notes from the right edge', () => {
             cancelable: true,
         }));
         assert.equal(notes.hidden, true);
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('does not resize PDF notes during a vertical scrollbar drag', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1014, 420);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1014, 420);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('cancels a notes resize when a gesture becomes vertical', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1010, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1012, 420);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1012, 420);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('cancels an accidental notes resize when the editor starts scrolling', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+    const scroller = shadow.querySelector('.cm-scroller');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1010, 300);
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '290px'
+        );
+
+        scroller.dispatchEvent(new document.defaultView.Event('scroll'));
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1080, 300);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1080, 300);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
     }
     finally {
         view.destroy();

--- a/test/markdown-window.test.js
+++ b/test/markdown-window.test.js
@@ -82,7 +82,7 @@ function createTestInlineEditor({ document, parent, initialMarkdown }) {
     };
 }
 
-function dispatchMouseEvent(target, type, clientX, clientY = 0) {
+function dispatchMouseEvent(target, type, clientX, clientY = 0, buttons) {
     const ownerWindow = target.ownerDocument?.defaultView || target;
     const event = new ownerWindow.Event(type, {
         bubbles: true,
@@ -93,6 +93,9 @@ function dispatchMouseEvent(target, type, clientX, clientY = 0) {
         clientX: { value: clientX },
         clientY: { value: clientY },
     });
+    if (buttons !== undefined) {
+        Object.defineProperty(event, 'buttons', { value: buttons });
+    }
     target.dispatchEvent(event);
 }
 
@@ -1027,6 +1030,162 @@ test('cancels an accidental notes resize when the editor starts scrolling', () =
     finally {
         view.destroy();
     }
+});
+
+test('cancels a notes resize when an outer editor container starts scrolling', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+    const workspace = shadow.querySelector('.markdown-workspace');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1010, 300);
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '290px'
+        );
+
+        workspace.dispatchEvent(new document.defaultView.Event('scroll'));
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1080, 300);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1080, 300);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('cancels a notes resize when the primary pointer button is released', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1010, 300, 1);
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '290px'
+        );
+
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1080, 300, 0);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1080, 300, 0);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('cancels a notes resize when the owning document starts scrolling', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1010, 300);
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '290px'
+        );
+
+        document.dispatchEvent(new document.defaultView.Event('scroll'));
+        dispatchMouseEvent(document.defaultView, 'mousemove', 1080, 300);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1080, 300);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('cancels a notes resize when a move loses its vertical coordinate', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+
+    try {
+        dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+        const event = new document.defaultView.Event('mousemove', {
+            bubbles: true,
+            cancelable: true,
+        });
+        Object.defineProperties(event, {
+            button: { value: 0 },
+            clientX: { value: 1010 },
+        });
+        document.defaultView.dispatchEvent(event);
+        dispatchMouseEvent(document.defaultView, 'mouseup', 1010, 300);
+
+        assert.equal(resizer.getAttribute('aria-valuenow'), '300');
+        assert.equal(
+            notes.style.getPropertyValue('--notes-width'),
+            '300px'
+        );
+    }
+    finally {
+        view.destroy();
+    }
+});
+
+test('removes side panel scroll listeners when the view is destroyed', () => {
+    const { document, view, shadow } = createView(createModel({
+        status: 'ready',
+        progress: 100,
+        markdown: 'Annotated text',
+        sourceKind: 'markdown',
+    }));
+    const notes = shadow.querySelector('#mktero-notes');
+    const resizer = shadow.querySelector('#mktero-notes-resizer');
+    const workspace = shadow.querySelector('.markdown-workspace');
+
+    dispatchMouseEvent(resizer, 'mousedown', 1000, 300);
+    dispatchMouseEvent(document.defaultView, 'mousemove', 1010, 300);
+    view.destroy();
+
+    workspace.dispatchEvent(new document.defaultView.Event('scroll'));
+
+    assert.equal(
+        notes.style.getPropertyValue('--notes-width'),
+        '290px'
+    );
 });
 
 test('collapses side panels responsively and restores automatic changes', () => {

--- a/test/pdf-annotation-text.test.js
+++ b/test/pdf-annotation-text.test.js
@@ -21,8 +21,28 @@ test('normalizes mathematical operator whitespace while preserving source ranges
     assert.equal(normalizePdfAnnotationText('well - being'), 'well - being');
 });
 
+test('normalizes PDF.js spacing around degree units while preserving source ranges', () => {
+    const markdown = 'Basal body temperature increases by 0.3 °C.';
+    const pdf = 'Basal body temperature increases by 0.3   ° C.';
+    const markdownIndex = createPdfAnnotationTextIndex(markdown);
+    const pdfIndex = createPdfAnnotationTextIndex(pdf);
+
+    assert.equal(pdfIndex.text, markdownIndex.text);
+    assert.equal(
+        pdfIndex.text,
+        'Basal body temperature increases by 0.3°C.'
+    );
+
+    const target = '0.3°C';
+    const range = pdfIndex.sourceRange(
+        pdfIndex.text.indexOf(target),
+        target.length
+    );
+    assert.equal(pdf.slice(range.from, range.to), '0.3   ° C');
+});
+
 test('normalizes MinerU LaTeX symbols while preserving source ranges', () => {
-    const markdown = 'Difference 0.30\\;^{\\circ}C; window \\pm2.';
+    const markdown = 'Difference 0.30\\;^{\\circ}\\mathrm{C}; window \\pm2.';
     const pdf = 'Difference 0.30 °C; window ± 2.';
     const markdownIndex = createPdfAnnotationTextIndex(markdown);
     const pdfIndex = createPdfAnnotationTextIndex(pdf);
@@ -42,7 +62,7 @@ test('normalizes MinerU LaTeX symbols while preserving source ranges', () => {
     );
     assert.equal(
         markdown.slice(markdownDegreeRange.from, markdownDegreeRange.to),
-        '0.30\\;^{\\circ}C'
+        '0.30\\;^{\\circ}\\mathrm{C}'
     );
     assert.equal(
         pdf.slice(pdfDegreeRange.from, pdfDegreeRange.to),
@@ -59,6 +79,24 @@ test('normalizes MinerU LaTeX symbols while preserving source ranges', () => {
         '\\pm2'
     );
     assert.equal(normalizePdfAnnotationText('\\pmod2'), '\\pmod2');
+});
+
+test('normalizes LaTeX temperature units from saved Markdown annotations', () => {
+    const markdown = 'Temperature increased by 0.3^{\\circ}\\mathrm{C}.';
+    const pdf = 'Temperature increased by 0.3 °C.';
+    const markdownIndex = createPdfAnnotationTextIndex(markdown);
+    const pdfIndex = createPdfAnnotationTextIndex(pdf);
+
+    assert.equal(markdownIndex.text, 'Temperature increased by 0.3°C.');
+    assert.equal(markdownIndex.text, pdfIndex.text);
+    const range = markdownIndex.sourceRange(
+        markdownIndex.text.indexOf('0.3°C'),
+        '0.3°C'.length
+    );
+    assert.equal(
+        markdown.slice(range.from, range.to),
+        '0.3^{\\circ}\\mathrm{C}'
+    );
 });
 
 test('leaves escaped, malformed, and oversized LaTeX-like input unchanged', () => {

--- a/test/zotero-annotation-actions.test.js
+++ b/test/zotero-annotation-actions.test.js
@@ -764,6 +764,36 @@ test('locates MinerU LaTeX and statistical text in the PDF', async () => {
     assert.equal(result.savedJSON.text, STATISTICAL_MARKDOWN_PASSAGE);
 });
 
+test('locates PDF.js text with spaces around a degree unit', async () => {
+    const markdownPassage = 'basal body temperature increases by 0.3 °C';
+    const pdfPassage = 'basal body temperature increases by 0.3   ° C';
+    const result = await createAnnotationWithNormalizedPDFSearch(
+        markdownPassage,
+        pdfPassage
+    );
+
+    assert.equal(result.created.id, 'SYNC0001');
+    assert.deepEqual(result.queries, [markdownPassage, pdfPassage]);
+    assert.equal(result.savedJSON.text, markdownPassage);
+});
+
+test('locates saved Markdown LaTeX temperature text in the PDF', async () => {
+    const markdownPassage = 'Luteinizing hormones (LH) surge when a female '
+        + 'individual is ovulating and basal body temperature increases by '
+        + '0.3^{\\circ}\\mathrm{C}';
+    const pdfPassage = 'Luteinizing hormones (LH) surge when a female '
+        + 'individual is ovulating and basal body temperature increases by '
+        + '0.3 °C';
+    const result = await createAnnotationWithNormalizedPDFSearch(
+        markdownPassage,
+        pdfPassage
+    );
+
+    assert.equal(result.created.id, 'SYNC0001');
+    assert.deepEqual(result.queries, [markdownPassage, pdfPassage]);
+    assert.equal(result.savedJSON.text, markdownPassage);
+});
+
 test('locates the menstrual-cycle abstract across PDF.js nonbreaking hyphens', async () => {
     for (const {
         markdownPassage,

--- a/test/zotero-saved-markdown-store.test.js
+++ b/test/zotero-saved-markdown-store.test.js
@@ -413,6 +413,31 @@ test('saves a portable snapshot and synced source attachments under the parent i
     assert.deepEqual(importedContentTypes, ['text/markdown', 'application/json']);
 });
 
+test('does not let an invalid source map block a portable snapshot', async () => {
+    const { parent, pdf, store } = createHarness();
+    const markdown = 'Results from the menstrual-cycle study.';
+    const result = await store.saveSnapshot({
+        pdfItem: pdf,
+        parentItem: parent,
+        markdown,
+        assets: [],
+        sourceMap: [{
+            type: 'text',
+            markdownFrom: 0,
+            markdownTo: markdown.length + 1,
+            locations: [{ pageIndex: 0, bbox: [0, 0, 100, 100] }],
+        }],
+        cacheKey: 'a'.repeat(64),
+        parserProfile: 'mineru-v1',
+    });
+
+    const saved = await store.read(result.note);
+
+    assert.equal(saved.sourceAvailable, true);
+    assert.deepEqual(saved.sourceMap, []);
+    assert.match(saved.markdown, /menstrual-cycle/);
+});
+
 test('recognizes a saved snapshot after Zotero wraps the note HTML', async () => {
     const { parent, pdf, store } = createHarness();
     const result = await store.saveSnapshot({

--- a/ui/markdown.css
+++ b/ui/markdown.css
@@ -140,6 +140,12 @@ main {
     touch-action: none;
 }
 
+.markdown-notes-resizer {
+    inset-block: 0;
+    inset-inline-start: 4px;
+    inset-inline-end: 0;
+}
+
 .markdown-side-panel-resizer::before {
     position: absolute;
     inset: 0 2px;


### PR DESCRIPTION
## Summary
- Fix snapshot saving and PDF annotation synchronization.
- Prevent accidental Notes panel resizing while Markdown content or outer Zotero containers scroll.
- Cancel stale resize state when pointer buttons or coordinates are invalid, and clean up capture listeners.

## Verification
- npm test (742 passed)
- npm run check
- npm run build