### PR TITLE
chore: prepare Mktero 0.2.6 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,8 +278,8 @@ npm run build
 构建结果位于：
 
 - `build/package/`：未压缩插件目录
-- `build/mktero-0.2.5.xpi`：可安装插件包
-- `build/mktero-0.2.5.xpi.sha256`：只引用 XPI 文件名的 SHA-256 校验文件
+- `build/mktero-0.2.6.xpi`：可安装插件包
+- `build/mktero-0.2.6.xpi.sha256`：只引用 XPI 文件名的 SHA-256 校验文件
 - `build/updates.json`：与当前版本、下载地址和 XPI 哈希一致的 Zotero 更新清单
 
 XPI 中的文件顺序和时间戳固定；相同源码与依赖连续构建会得到相同的 XPI 哈希。
@@ -314,8 +314,8 @@ scripts/build.mjs  esbuild 与 XPI 打包脚本
 随后创建带 `v` 前缀、与清单版本完全一致的标签：
 
 ```bash
-git tag v0.2.5
-git push origin v0.2.5
+git tag v0.2.6
+git push origin v0.2.6
 ```
 
 标签推送后，[Release 工作流](./.github/workflows/release.yml)会自动执行语法检查、完整测试

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.2.5",
+      "version": "0.2.6",
       "dependencies": {
         "@codemirror/commands": "6.10.4",
         "@codemirror/lang-markdown": "6.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -36,7 +36,7 @@ test('declares the scalable Mktero logo for extension surfaces', () => {
 });
 
 test('keeps the installable package version metadata consistent', () => {
-    assert.equal(manifest.version, '0.2.5');
+    assert.equal(manifest.version, '0.2.6');
     assert.equal(packageMetadata.version, manifest.version);
     assert.equal(packageLock.version, manifest.version);
     assert.equal(packageLock.packages[''].version, manifest.version);


### PR DESCRIPTION
## Summary
- Bump Mktero version metadata from 0.2.5 to 0.2.6.
- Update the version consistency test and current release documentation.
- Keep the historical 0.2.5 snapshot compatibility note unchanged.

## Verification
- npm run check
- npm test (742 passed)
- npm run build

After merging, push the annotated tag v0.2.6 to trigger the release workflow.