### PR TITLE
Fix deferred Markdown rendering after partial parsing

### DIFF
--- a/src/editor/inline-rendering.js
+++ b/src/editor/inline-rendering.js
@@ -480,6 +480,8 @@ export function createInlineRenderingExtension({
             const shouldRefresh = transaction.effects.some(effect => (
                 effect.is(refreshInlineRendering)
             ));
+            const syntaxTreeChanged = syntaxTree(transaction.startState)
+                !== syntaxTree(transaction.state);
             let referenceHighlightChanged = false;
             let tableHighlightChanged = false;
             let figureHighlightChanged = false;
@@ -510,6 +512,7 @@ export function createInlineRenderingExtension({
                 }
             }
             if (transaction.docChanged
+                || syntaxTreeChanged
                 || referenceHighlightChanged
                 || tableHighlightChanged
                 || figureHighlightChanged

--- a/test/inline-markdown-editor.test.js
+++ b/test/inline-markdown-editor.test.js
@@ -1,5 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import {
+    forceParsing,
+    syntaxTreeAvailable,
+} from '@codemirror/language';
 import { EditorView } from '@codemirror/view';
 import { JSDOM } from 'jsdom';
 import {
@@ -57,6 +61,17 @@ function rectangle(top, right, bottom, left) {
         width: right - left,
         height: bottom - top,
     };
+}
+
+function hasRenderedWidget(view, display) {
+    let found = false;
+    for (const decorations of view.state.facet(EditorView.decorations)) {
+        if (typeof decorations === 'function') continue;
+        decorations.between(0, view.state.doc.length, (_from, _to, decoration) => {
+            if (decoration.spec.widget?.display === display) found = true;
+        });
+    }
+    return found;
 }
 
 function setSelectionGeometry(range, pointerLine, rectangles, lineRect) {
@@ -331,6 +346,8 @@ test('does not render PDF source buttons beside mapped Markdown blocks', () => {
     });
 
     editor.setDocument({ markdown, sourceMap });
+    const view = EditorView.findFromDOM(document.querySelector('.cm-editor'));
+    assert.equal(forceParsing(view, view.state.doc.length, 1000), true);
 
     assert.equal(
         document.querySelectorAll('.cm-mktero-source-link').length,
@@ -339,6 +356,34 @@ test('does not render PDF source buttons beside mapped Markdown blocks', () => {
     assert.ok(document.querySelector('.cm-mktero-image'));
     assert.ok(document.querySelector('.cm-mktero-math-display'));
     assert.ok(document.querySelector('.cm-mktero-table'));
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('refreshes rendered widgets after deferred Markdown parsing completes', () => {
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const prefix = Array.from(
+        { length: 120 },
+        (_, index) => (
+            `Paragraph ${index + 1} contains enough text to extend the initial parse.`
+        )
+    ).join('\n\n');
+    const markdown = `${prefix}\n\n$$\nE = mc^2\n$$`;
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+    });
+    const view = EditorView.findFromDOM(document.querySelector('.cm-editor'));
+
+    assert.equal(syntaxTreeAvailable(view.state), false);
+    assert.equal(hasRenderedWidget(view, 'math-display'), false);
+    assert.equal(forceParsing(view, view.state.doc.length, 1000), true);
+    assert.equal(syntaxTreeAvailable(view.state), true);
+    assert.equal(hasRenderedWidget(view, 'math-display'), true);
 
     editor.destroy();
     dom.window.close();


### PR DESCRIPTION
## Summary

- rebuild inline Markdown decorations when CodeMirror publishes a newer syntax tree
- make the mapped-block test explicitly finish parsing before DOM assertions
- add a deterministic regression test for rendering after CodeMirror's bounded initial parse completes

## Root cause

CodeMirror limits synchronous parsing during a document update. Under CI scheduler contention, the transaction could expose a partial syntax tree. Mktero built decorations from that tree but did not rebuild them when background parsing completed, leaving display math (and later blocks) unrendered.

## Verification

- `npm run check`
- `npm test` (869/869)
- `npm run build`

Version remains 0.2.7.