### PR TITLE
Release Mktero 0.2.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ for current limits.
 
 ### Install
 
-1. Download `mktero-<version>.xpi` from
+1. Download `mktero-0.2.8.xpi` from
    [GitHub Releases](https://github.com/tenglvjun/mktero/releases/latest).
 2. In Zotero, open `Tools -> Plugins`.
 3. Open the gear menu and choose `Install Add-on From File...`.
@@ -230,14 +230,22 @@ npm run build
 ```
 
 The build creates the unpacked extension, a reproducible
-`build/mktero-<version>.xpi`, its SHA-256 checksum, and `build/updates.json`.
+`build/mktero-0.2.8.xpi`, its SHA-256 checksum, and `build/updates.json`.
 Generated `build/` and `node_modules/` directories are ignored and must not be
 committed.
 
-Before creating a `v<version>` tag, keep the versions in `manifest.json`,
-`package.json`, and `package-lock.json` consistent. The release workflow checks
-the tag against `manifest.json` before publishing. Pushes and pull requests run
-the test, build, and CodeQL workflows without publishing a release.
+Before creating the release tag, keep the versions in `manifest.json`,
+`package.json`, and `package-lock.json` consistent. Create and push the annotated
+tag with:
+
+```bash
+git tag v0.2.8 -m "Mktero 0.2.8"
+git push origin v0.2.8
+```
+
+The release workflow checks the tag against `manifest.json` before publishing.
+Pushes and pull requests run the test, build, and CodeQL workflows without
+publishing a release.
 
 See [AGENTS.md](./AGENTS.md) for the repository architecture, coding rules,
 security invariants, and cross-file change checklist.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.2.7",
+      "version": "0.2.8",
       "dependencies": {
         "@codemirror/commands": "6.10.4",
         "@codemirror/lang-markdown": "6.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -36,7 +36,7 @@ test('declares the scalable Mktero logo for extension surfaces', () => {
 });
 
 test('keeps the installable package version metadata consistent', () => {
-    assert.equal(manifest.version, '0.2.7');
+    assert.equal(manifest.version, '0.2.8');
     assert.equal(packageMetadata.version, manifest.version);
     assert.equal(packageLock.version, manifest.version);
     assert.equal(packageLock.packages[''].version, manifest.version);


### PR DESCRIPTION
## Summary

- update Mktero version metadata to 0.2.8
- document the 0.2.8 release artifact and annotated tag commands
- keep manifest, package, lockfile, and tests consistent

## Validation

- `npm ci`
- `npm run check`
- `npm test`
- `npm run build`