### PR TITLE
修复 hiddenDOMWindow 不可用时的运行时回退

### DIFF
--- a/src/platform/abort-controller.js
+++ b/src/platform/abort-controller.js
@@ -3,22 +3,21 @@ export function createRuntimeAbortController({
     zotero = globalObject?.Zotero,
     services = globalObject?.Services,
 } = {}) {
-    if (typeof globalObject?.AbortController === 'function') {
-        return new globalObject.AbortController();
+    for (const resolveOwner of [
+        () => globalObject,
+        () => zotero?.getMainWindow?.(),
+        () => services?.appShell?.hiddenDOMWindow,
+    ]) {
+        let Constructor = null;
+        try {
+            Constructor = resolveOwner()?.AbortController;
+        }
+        catch {
+            continue;
+        }
+        if (typeof Constructor === 'function') {
+            return new Constructor();
+        }
     }
-    let owner = null;
-    try {
-        owner = zotero?.getMainWindow?.();
-    }
-    catch {
-        owner = null;
-    }
-    const hiddenWindow = services?.appShell?.hiddenDOMWindow;
-    const Constructor = [owner, hiddenWindow]
-        .map(candidate => candidate?.AbortController)
-        .find(candidate => typeof candidate === 'function');
-    if (!Constructor) {
-        throw new Error('AbortController is unavailable in the Zotero runtime');
-    }
-    return new Constructor();
+    throw new Error('AbortController is unavailable in the Zotero runtime');
 }

--- a/src/platform/web-streams.js
+++ b/src/platform/web-streams.js
@@ -9,7 +9,31 @@ try {
 catch {
     mainWindow = null;
 }
-const hiddenWindow = globalThis.Services?.appShell?.hiddenDOMWindow;
+
+let hiddenWindow = null;
+let hiddenWindowResolved = false;
+
+function resolveHiddenWindow() {
+    if (hiddenWindowResolved) return hiddenWindow;
+    hiddenWindowResolved = true;
+    try {
+        hiddenWindow = globalThis.Services?.appShell?.hiddenDOMWindow || null;
+    }
+    catch {
+        hiddenWindow = null;
+    }
+    return hiddenWindow;
+}
+
+function resolveConstructor(owner, name) {
+    try {
+        const Constructor = owner?.[name];
+        return typeof Constructor === 'function' ? Constructor : null;
+    }
+    catch {
+        return null;
+    }
+}
 
 for (const name of [
     'ReadableStream',
@@ -18,8 +42,8 @@ for (const name of [
     'TextDecoderStream',
     'TextEncoderStream',
 ]) {
-    if (typeof globalThis[name] !== 'function'
-        && typeof (mainWindow?.[name] || hiddenWindow?.[name]) === 'function') {
-        globalThis[name] = mainWindow?.[name] || hiddenWindow[name];
-    }
+    if (typeof globalThis[name] === 'function') continue;
+    const Constructor = resolveConstructor(mainWindow, name)
+        || resolveConstructor(resolveHiddenWindow(), name);
+    if (Constructor) globalThis[name] = Constructor;
 }

--- a/src/platform/zotero-saved-markdown-store.js
+++ b/src/platform/zotero-saved-markdown-store.js
@@ -894,21 +894,23 @@ export function createZoteroBlobFactory({
     globalObject = globalThis,
 } = {}) {
     return (parts, options) => {
-        let mainWindow = null;
-        try {
-            mainWindow = zotero?.getMainWindow?.() || null;
+        for (const resolveOwner of [
+            () => zotero?.getMainWindow?.(),
+            () => services?.appShell?.hiddenDOMWindow,
+            () => globalObject,
+        ]) {
+            let BlobType = null;
+            try {
+                BlobType = resolveOwner()?.Blob;
+            }
+            catch {
+                continue;
+            }
+            if (typeof BlobType === 'function') {
+                return new BlobType(parts, options);
+            }
         }
-        catch {
-            mainWindow = null;
-        }
-        const hiddenDOMWindow = services?.appShell?.hiddenDOMWindow || null;
-        const BlobType = [mainWindow, hiddenDOMWindow, globalObject]
-            .map(window => window?.Blob)
-            .find(candidate => typeof candidate === 'function');
-        if (!BlobType) {
-            throw new Error('The Zotero runtime cannot create image attachments');
-        }
-        return new BlobType(parts, options);
+        throw new Error('The Zotero runtime cannot create image attachments');
     };
 }
 

--- a/test/abort-controller.test.js
+++ b/test/abort-controller.test.js
@@ -16,6 +16,27 @@ test('prefers the plugin global AbortController without consulting Zotero window
     assert.ok(controller instanceof SandboxAbortController);
 });
 
+test('uses the main window AbortController without consulting the hidden window', () => {
+    class MainWindowAbortController {}
+    const controller = createRuntimeAbortController({
+        globalObject: {},
+        zotero: {
+            getMainWindow: () => ({
+                AbortController: MainWindowAbortController,
+            }),
+        },
+        services: {
+            appShell: {
+                get hiddenDOMWindow() {
+                    throw new Error('NS_ERROR_FAILURE');
+                },
+            },
+        },
+    });
+
+    assert.ok(controller instanceof MainWindowAbortController);
+});
+
 test('falls back to the hidden DOM AbortController without a main window', () => {
     class HiddenAbortController {}
     const controller = createRuntimeAbortController({

--- a/test/build-artifacts.test.js
+++ b/test/build-artifacts.test.js
@@ -168,6 +168,13 @@ test('bridges Web Streams from the Zotero main window before AI SDK loading', as
     };
     const context = vm.createContext({
         Zotero: { getMainWindow: () => streams },
+        Services: {
+            appShell: {
+                get hiddenDOMWindow() {
+                    throw new Error('NS_ERROR_FAILURE');
+                },
+            },
+        },
     });
     vm.runInContext(source, context);
     assert.equal(context.ReadableStream, streams.ReadableStream);

--- a/test/zotero-saved-markdown-store.test.js
+++ b/test/zotero-saved-markdown-store.test.js
@@ -264,6 +264,13 @@ test('uses the Zotero main window Blob constructor before the plugin global', ()
         zotero: {
             getMainWindow: () => ({ Blob: BlobType }),
         },
+        services: {
+            appShell: {
+                get hiddenDOMWindow() {
+                    throw new Error('NS_ERROR_FAILURE');
+                },
+            },
+        },
         globalObject: {},
     });
     const originalBlob = globalThis.Blob;
@@ -277,6 +284,23 @@ test('uses the Zotero main window Blob constructor before the plugin global', ()
     finally {
         globalThis.Blob = originalBlob;
     }
+});
+
+test('falls back to the plugin global Blob when Zotero windows are unavailable', () => {
+    class SandboxBlob {}
+    const factory = createZoteroBlobFactory({
+        zotero: { getMainWindow: () => null },
+        services: {
+            appShell: {
+                get hiddenDOMWindow() {
+                    throw new Error('NS_ERROR_FAILURE');
+                },
+            },
+        },
+        globalObject: { Blob: SandboxBlob },
+    });
+
+    assert.ok(factory([], {}) instanceof SandboxBlob);
 });
 
 test('saves source files when Zotero restricts ordinary attachments to regular items', async () => {


### PR DESCRIPTION
## 变更说明

- 按优先级惰性解析 Zotero 主窗口、隐藏窗口和插件全局中的运行时构造器
- 当 `hiddenDOMWindow` 等特权 getter 抛出异常时继续使用可用候选
- 同步加固 Blob、AbortController 和 Web Streams 路径
- 添加 `NS_ERROR_FAILURE` 回归测试

## 根因

`Services.appShell.hiddenDOMWindow` 是可能抛出异常的 XPCOM getter。原实现会急切读取所有候选，因此即使主窗口已经提供可用的 Blob，隐藏窗口的异常仍会中断 Save snapshot。

## 验证

- `npm run check`
- `npm test`（1109 项通过）
- `npm run build`

Fixes #59