### PR TITLE
Release Mktero 0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for current limits.
 
 ### Install
 
-1. Download `mktero-0.2.8.xpi` from
+1. Download `mktero-0.3.0.xpi` from
    [GitHub Releases](https://github.com/tenglvjun/mktero/releases/latest).
 2. In Zotero, open `Tools -> Plugins`.
 3. Open the gear menu and choose `Install Add-on From File...`.
@@ -391,7 +391,7 @@ npm run build
 ```
 
 The build creates the unpacked extension, a reproducible
-`build/mktero-0.2.8.xpi`, its SHA-256 checksum, and `build/updates.json`.
+`build/mktero-0.3.0.xpi`, its SHA-256 checksum, and `build/updates.json`.
 Generated `build/` and `node_modules/` directories are ignored and must not be
 committed.
 
@@ -400,8 +400,8 @@ Before creating the release tag, keep the versions in `manifest.json`,
 tag with:
 
 ```bash
-git tag v0.2.8 -m "Mktero 0.2.8"
-git push origin v0.2.8
+git tag v0.3.0 -m "Mktero 0.3.0"
+git push origin v0.3.0
 ```
 
 The release workflow checks the tag against `manifest.json` before publishing.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.2.8",
+      "version": "0.3.0",
       "dependencies": {
         "@ai-sdk/alibaba": "^2.0.31",
         "@ai-sdk/anthropic": "^4.0.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.2.8",
+  "version": "0.3.0",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -36,7 +36,7 @@ test('declares the scalable Mktero logo for extension surfaces', () => {
 });
 
 test('keeps the installable package version metadata consistent', () => {
-    assert.equal(manifest.version, '0.2.8');
+    assert.equal(manifest.version, '0.3.0');
     assert.equal(packageMetadata.version, manifest.version);
     assert.equal(packageLock.version, manifest.version);
     assert.equal(packageLock.packages[''].version, manifest.version);


### PR DESCRIPTION
## Summary

- update extension and package metadata to 0.3.0
- update the manifest version assertion
- update README download, build artifact, and annotated tag examples

## Validation

- `npm ci`
- `npm run check`
- `npm test`
- `npm run build`

Generated `mktero-0.3.0.xpi`, its checksum, packaged manifest, and `updates.json` were also verified locally.