### PR TITLE
Release Mktero 0.3.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ for current limits.
 
 ### Install
 
-1. Download `mktero-0.3.0.xpi` from
+1. Download `mktero-0.3.1.xpi` from
    [GitHub Releases](https://github.com/tenglvjun/mktero/releases/latest).
 2. In Zotero, open `Tools -> Plugins`.
 3. Open the gear menu and choose `Install Add-on From File...`.
@@ -412,7 +412,7 @@ npm run build
 ```
 
 The build creates the unpacked extension, a reproducible
-`build/mktero-0.3.0.xpi`, its SHA-256 checksum, and `build/updates.json`.
+`build/mktero-0.3.1.xpi`, its SHA-256 checksum, and `build/updates.json`.
 Generated `build/` and `node_modules/` directories are ignored and must not be
 committed.
 
@@ -421,8 +421,8 @@ Before creating the release tag, keep the versions in `manifest.json`,
 tag with:
 
 ```bash
-git tag v0.3.0 -m "Mktero 0.3.0"
-git push origin v0.3.0
+git tag v0.3.1 -m "Mktero 0.3.1"
+git push origin v0.3.1
 ```
 
 The release workflow checks the tag against `manifest.json` before publishing.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@ai-sdk/alibaba": "^2.0.31",
         "@ai-sdk/anthropic": "^4.0.38",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",

--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -36,7 +36,7 @@ test('declares the scalable Mktero logo for extension surfaces', () => {
 });
 
 test('keeps the installable package version metadata consistent', () => {
-    assert.equal(manifest.version, '0.3.0');
+    assert.equal(manifest.version, '0.3.1');
     assert.equal(packageMetadata.version, manifest.version);
     assert.equal(packageLock.version, manifest.version);
     assert.equal(packageLock.packages[''].version, manifest.version);


### PR DESCRIPTION
## Release

Prepare Mktero `0.3.1` for publication.

- update the extension, package, lockfile, and manifest-version test metadata
- update the documented XPI filename and annotated tag commands
- keep the release artifact and update metadata aligned with `v0.3.1`

## Validation

- `npm ci`
- `npm run check`
- `npm test`
- `npm run build`

Generated artifact checks passed for `build/mktero-0.3.1.xpi`, its SHA-256 checksum, `build/package/manifest.json`, and `build/updates.json`.
