### PR TITLE
Fix citation hover for numbered references and tables

### DIFF
--- a/src/editor/inline-rendering.js
+++ b/src/editor/inline-rendering.js
@@ -2225,6 +2225,12 @@ function renderedRange(node, state, display, context) {
                 annotationSource: state.sliceDoc(node.from, node.to),
                 annotationSourceFrom: node.from,
                 caption: node.caption,
+                citations: renderedCitationDescriptors(
+                    state,
+                    context,
+                    node.from,
+                    node.to
+                ),
                 highlighted: tableIsHighlighted,
                 annotations,
                 correctionBlock,
@@ -2250,6 +2256,8 @@ function renderedRange(node, state, display, context) {
             display,
             from: node.from,
             citations: display === 'image'
+                || (display === 'html-block'
+                    && /^\s*<table\b/i.test(source))
                 ? renderedCitationDescriptors(
                     state,
                     context,

--- a/src/editor/rendered-markdown-dom.js
+++ b/src/editor/rendered-markdown-dom.js
@@ -67,16 +67,16 @@ export function installRenderedImagePreview(
 }
 
 export function installRenderedCitations(container, citations = []) {
-    const caption = container.querySelector('figcaption');
-    if (!caption || !citations.length) return;
+    const target = container.querySelector('figcaption, table') || container;
+    if (!target || !citations.length) return;
 
-    const captionText = caption.textContent || '';
+    const targetText = target.textContent || '';
     let markerSearchFrom = 0;
     let previousMarkerFrom = null;
     let markerIndex = -1;
     for (const citation of citations) {
         if (citation.markerFrom !== previousMarkerFrom) {
-            markerIndex = captionText.indexOf(
+            markerIndex = targetText.indexOf(
                 citation.marker,
                 markerSearchFrom
             );
@@ -85,8 +85,8 @@ export function installRenderedCitations(container, citations = []) {
             previousMarkerFrom = citation.markerFrom;
         }
         if (markerIndex < 0) continue;
-        wrapCaptionText(
-            caption,
+        wrapRenderedText(
+            target,
             markerIndex + citation.targetOffset,
             citation.targetLength,
             citation
@@ -94,11 +94,11 @@ export function installRenderedCitations(container, citations = []) {
     }
 }
 
-function wrapCaptionText(caption, from, length, citation) {
-    const document = caption.ownerDocument;
+function wrapRenderedText(target, from, length, citation) {
+    const document = target.ownerDocument;
     const nodeFilter = document.defaultView.NodeFilter;
     const walker = document.createTreeWalker(
-        caption,
+        target,
         nodeFilter.SHOW_TEXT
     );
     let offset = 0;

--- a/src/editor/rendered-table-widget.js
+++ b/src/editor/rendered-table-widget.js
@@ -2,6 +2,7 @@ import { WidgetType } from '@codemirror/view';
 import { parseGFMTableRow } from '../markdown/markdown-tables.js';
 import {
     appendRenderedMarkdown,
+    installRenderedCitations,
     installRenderedImagePreview,
     openRenderedLink,
 } from './rendered-markdown-dom.js';
@@ -25,6 +26,7 @@ export class RenderedTableWidget extends WidgetType {
         openLink,
         openImagePreview,
         renderVersion,
+        citations = [],
         highlighted = false,
         annotations = [],
         correctionBlock = null,
@@ -46,6 +48,8 @@ export class RenderedTableWidget extends WidgetType {
         this.openLink = openLink;
         this.openImagePreview = openImagePreview;
         this.renderVersion = renderVersion;
+        this.citations = citations;
+        this.citationKey = citations.map(citation => citation.key).join('|');
         this.highlighted = highlighted;
         this.annotations = annotations;
         this.annotationKey = JSON.stringify(annotations);
@@ -71,6 +75,7 @@ export class RenderedTableWidget extends WidgetType {
             && this.annotationSourceFrom === other.annotationSourceFrom
             && this.caption?.text === other.caption?.text
             && this.renderVersion === other.renderVersion
+            && this.citationKey === other.citationKey
             && this.highlighted === other.highlighted
             && this.annotationKey === other.annotationKey
             && this.correctionBlock?.id === other.correctionBlock?.id
@@ -110,6 +115,7 @@ export class RenderedTableWidget extends WidgetType {
         if (table && this.caption) {
             table.prepend(createTableCaption(document, this.caption));
         }
+        installRenderedCitations(container, this.citations);
         this.#configureCells(container);
         installRenderedAnnotations(
             container,

--- a/src/markdown/markdown-citations.js
+++ b/src/markdown/markdown-citations.js
@@ -2,7 +2,8 @@ import {
     isLikelyNumericSuperscriptExponent,
 } from './text-normalization.js';
 
-const REFERENCE_HEADING_PATTERN = /^(?:(#{1,6})[ \t]+)?(?:\*{1,2}|_{1,2})?(?:references?|bibliography|works[ \t]+cited|literature[ \t]+cited|参考文献|参考资料|参考书目)(?:\*{1,2}|_{1,2})?[ \t]*[:：]?[ \t]*#*[ \t]*$/gim;
+const REFERENCE_HEADING_PATTERN = /^(?:(#{1,6})[ \t]+)?(?:\*{1,2}|_{1,2})?(?:(?:\d+(?:\.\d+)*)[.)]?[ \t]+)?(?:references?|bibliography|works[ \t]+cited|literature[ \t]+cited|参考文献|参考资料|参考书目)(?:\*{1,2}|_{1,2})?[ \t]*[:：]?[ \t]*#*[ \t]*$/gim;
+const AUTHOR_AFFILIATIONS_HEADING_PATTERN = /^#{1,6}[ \t]+(?:author[ \t]+affiliations?|作者单位|作者机构)[ \t]*#*[ \t]*$/gim;
 const MAIN_CONTENT_HEADING_PATTERN = /^(?:(?:#{1,6})[ \t]+)?(?:\*{1,2}|_{1,2})?(?:(?:\d+(?:\.\d+)*)[.)]?[ \t]+)?(?:abstract|summary|background|introduction|materials?[ \t]+and[ \t]+methods|methods?|results?|摘要|背景|引言|绪论|材料与方法|方法|结果)(?:\*{1,2}|_{1,2})?[ \t]*[:：]?[ \t]*#*[ \t]*$/gim;
 const FRONT_MATTER_HEADING_PATTERN = /^(?:authors?(?:[ \t]+(?:details?|information))?|affiliations?|institutional[ \t]+affiliations?|institutions?|departments?|correspond(?:ence|ing[ \t]+authors?)|contact[ \t]+information|keywords?|作者|作者信息|作者单位|机构|所属机构|通讯作者|关键词)$/i;
 const MARKDOWN_HEADING_PATTERN = /^(#{1,6})[ \t]+.+$/gm;
@@ -37,18 +38,23 @@ export function analyzeMarkdownCitations(markdown) {
     const references = section ? parseReferences(source, section) : [];
     const bodyEnd = section?.from ?? source.length;
     const frontMatter = analyzeFrontMatter(source, bodyEnd);
+    const citationBodyEnd = findAuthorAffiliationsStart(
+        source,
+        frontMatter.bodyFrom,
+        bodyEnd
+    ) ?? bodyEnd;
     const citations = [
         ...frontMatter.citations,
         ...findNumericCitations(
             source,
             frontMatter.bodyFrom,
-            bodyEnd,
+            citationBodyEnd,
             references
         ),
         ...findAuthorYearCitations(
             source,
             frontMatter.bodyFrom,
-            bodyEnd,
+            citationBodyEnd,
             references
         ),
     ].sort((left, right) => left.from - right.from || left.to - right.to);
@@ -58,6 +64,13 @@ export function analyzeMarkdownCitations(markdown) {
         affiliations: frontMatter.affiliations,
         citations: removeOverlappingCitations(citations),
     };
+}
+
+function findAuthorAffiliationsStart(markdown, from, to) {
+    const source = markdown.slice(from, to);
+    const heading = new RegExp(AUTHOR_AFFILIATIONS_HEADING_PATTERN)
+        .exec(source);
+    return heading ? from + heading.index : null;
 }
 
 function analyzeFrontMatter(markdown, bodyEnd) {
@@ -105,21 +118,28 @@ function analyzeFrontMatter(markdown, bodyEnd) {
 
 function findAuthorAreaStart(markdown, authorAreaEnd) {
     const source = markdown.slice(0, authorAreaEnd);
+    let authorAreaStart = 0;
+    let foundTitle = false;
     for (const heading of source.matchAll(new RegExp(MARKDOWN_HEADING_PATTERN))) {
         if (heading[1].length !== 1) continue;
+        if (foundTitle
+            && markdown.slice(authorAreaStart, heading.index).trim()) {
+            break;
+        }
         let from = heading.index + heading[0].length;
         if (markdown[from] === '\r') from++;
         if (markdown[from] === '\n') from++;
-        return from;
+        authorAreaStart = from;
+        foundTitle = true;
     }
-    return 0;
+    return authorAreaStart;
 }
 
 function findImplicitBodyStart(markdown, frontMatterEnd) {
-    const [paragraph] = paragraphRanges(markdown, {
+    const paragraph = paragraphRanges(markdown, {
         from: findAuthorAreaStart(markdown, frontMatterEnd),
         to: frontMatterEnd,
-    });
+    }).find(range => frontMatterParagraphHasProse(markdown, range));
     if (!paragraph) return null;
     const markers = findSuperscriptMarkers(
         markdown,
@@ -134,6 +154,12 @@ function findImplicitBodyStart(markdown, frontMatterEnd) {
         && paragraphLooksLikeByline(markdown, paragraph, markers)
         ? paragraph.to
         : paragraph.from;
+}
+
+function frontMatterParagraphHasProse(markdown, paragraph) {
+    const source = markdown.slice(paragraph.from, paragraph.to)
+        .replace(/!\[[^\]]*\]\([^)]*\)/g, ' ');
+    return /\p{L}/u.test(plainReferenceText(source));
 }
 
 function paragraphLooksLikeByline(markdown, paragraph, markers) {
@@ -158,14 +184,20 @@ function findMainContentStart(markdown, bodyEnd) {
     if (recognized) candidates.push(recognized.index);
 
     const headings = [...source.matchAll(new RegExp(MARKDOWN_HEADING_PATTERN))];
-    for (const [index, heading] of headings.entries()) {
+    let titleAreaEnd = null;
+    for (const heading of headings) {
         const level = heading[1].length;
         const label = heading[0]
             .slice(level)
             .replace(/[ \t]+#+[ \t]*$/, '')
             .trim();
-        if (index === 0 && level === 1
-            && !new RegExp(MAIN_CONTENT_HEADING_PATTERN).test(heading[0])) {
+        const isMainContent = new RegExp(MAIN_CONTENT_HEADING_PATTERN)
+            .test(heading[0]);
+        const followsOnlyTitles = titleAreaEnd === null
+            ? heading.index === 0
+            : !source.slice(titleAreaEnd, heading.index).trim();
+        if (level === 1 && !isMainContent && followsOnlyTitles) {
+            titleAreaEnd = heading.index + heading[0].length;
             continue;
         }
         if (FRONT_MATTER_HEADING_PATTERN.test(label)) continue;
@@ -473,6 +505,12 @@ function parseReferences(markdown, section) {
         }).filter(reference => reference.text);
     }
 
+    const bareNumberedReferences = parseBareNumberedReferences(
+        markdown,
+        section
+    );
+    if (bareNumberedReferences.length) return bareNumberedReferences;
+
     return unnumberedReferenceRanges(markdown, section)
         .map(({ from, to }, index) => createReference({
             id: `reference:${index + 1}`,
@@ -482,6 +520,42 @@ function parseReferences(markdown, section) {
             to,
         }))
         .filter(reference => reference.text && reference.year);
+}
+
+function parseBareNumberedReferences(markdown, section) {
+    const entries = paragraphRanges(markdown, section).map(range => {
+        const source = markdown.slice(range.from, range.to);
+        const marker = /^(\d{1,4})[ \t]+/.exec(source);
+        if (!marker) return null;
+        return {
+            number: Number(marker[1]),
+            from: range.from,
+            contentFrom: range.from + marker[0].length,
+            to: range.to,
+        };
+    });
+    if (!entries.length || entries.some(entry => !entry)) return [];
+
+    let previousNumber = 0;
+    for (const entry of entries) {
+        if (entry.number !== previousNumber
+            && entry.number !== previousNumber + 1) {
+            return [];
+        }
+        previousNumber = entry.number;
+    }
+    if (entries[0].number !== 1) return [];
+
+    return entries.map(entry => createReference({
+        id: `number:${entry.number}`,
+        number: entry.number,
+        text: plainReferenceText(markdown.slice(
+            entry.contentFrom,
+            entry.to
+        )),
+        from: entry.from,
+        to: entry.to,
+    })).filter(reference => reference.text);
 }
 
 function unnumberedReferenceRanges(markdown, section) {
@@ -592,7 +666,12 @@ function findNumericCitations(markdown, bodyFrom, bodyEnd, references) {
 
     const superscriptCitations = [];
     let superscriptCitationContainers = 0;
-    for (const marker of findSuperscriptMarkers(markdown, bodyFrom, bodyEnd)) {
+    for (const marker of findSuperscriptMarkers(
+        markdown,
+        bodyFrom,
+        bodyEnd,
+        { includeYearAdjacentMarkers: true }
+    )) {
         const matched = numericCitationsInText(
             marker.value,
             marker.from,
@@ -718,7 +797,10 @@ function findSuperscriptMarkers(
     markdown,
     from,
     to,
-    { includeLikelyExponents = false } = {}
+    {
+        includeLikelyExponents = false,
+        includeYearAdjacentMarkers = false,
+    } = {}
 ) {
     const source = markdown.slice(from, to);
     const markers = [];
@@ -731,7 +813,9 @@ function findSuperscriptMarkers(
                     markdown,
                     wrapperFrom,
                     value
-                )) {
+                )
+                && (!includeYearAdjacentMarkers
+                    || !superscriptFollowsYear(markdown, wrapperFrom))) {
                 continue;
             }
             const contentFrom = wrapperFrom + match[0].indexOf(match[1]);
@@ -761,7 +845,9 @@ function findSuperscriptMarkers(
                     markdown,
                     wrapperFrom,
                     value
-                ))) {
+                )
+                && (!includeYearAdjacentMarkers
+                    || !superscriptFollowsYear(markdown, wrapperFrom)))) {
             continue;
         }
         markers.push({
@@ -789,6 +875,12 @@ function findSuperscriptMarkers(
         occupiedUntil = marker.markup.wrapperTo;
     }
     return nonOverlapping;
+}
+
+function superscriptFollowsYear(markdown, from) {
+    const preceding = markdown.slice(Math.max(0, from - 32), from);
+    return /(?:18|19|20)\d{2}(?:\s*[-–—]\s*(?:18|19|20)?\d{2})?[ \t]+$/u
+        .test(preceding);
 }
 
 function normalizeSuperscriptCharacters(value) {

--- a/test/inline-markdown-editor.test.js
+++ b/test/inline-markdown-editor.test.js
@@ -3276,6 +3276,97 @@ test('renders a MinerU HTML table and its preceding caption as one table', () =>
     dom.window.close();
 });
 
+test('renders citations inside rendered tables as interactive references', () => {
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const markdown = [
+        '# Paper',
+        '',
+        '| Model |',
+        '| --- |',
+        '| Zhang et al. [16] |',
+        '',
+        '<table><tr><td>Kong et al. [41]</td></tr></table>',
+        '',
+        '## References',
+        '',
+        '[16] H. Zhang. Pedal estimation. 2025.',
+        '[41] Q. Kong. Piano transcription. 2021.',
+    ].join('\n');
+    const editor = createInlineMarkdownEditor({
+        document,
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+    });
+
+    const markdownCitation = document.querySelector(
+        '.cm-mktero-table .cm-mktero-citation'
+    );
+    const htmlCitation = document.querySelector(
+        '.cm-mktero-html-table .cm-mktero-citation'
+    );
+    assert.equal(markdownCitation?.textContent, '16');
+    assert.equal(htmlCitation?.textContent, '41');
+    htmlCitation?.dispatchEvent(new dom.window.MouseEvent('mouseover', {
+        bubbles: true,
+    }));
+    assert.match(
+        document.querySelector('.mktero-citation-popup')?.textContent || '',
+        /Q\. Kong\. Piano transcription\. 2021\./
+    );
+    assert.equal(editor.getMarkdown(), markdown);
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('renders table citations in bilingual documents with numbered references', () => {
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const markdown = [
+        '# MUSIC-JEPA',
+        '',
+        '## 4. RESULTS',
+        '',
+        '<table><tr><td>Kong et al. [41]</td></tr></table>',
+        '',
+        '## 6. REFERENCES',
+        '',
+        '## 6. 参考文献',
+        '',
+        '[41] Q. Kong. Piano transcription. 2021.',
+        '',
+        '[41] Q. Kong。钢琴转录。2021。',
+        '',
+        '[42] Y. Yan. Automatic transcription. 2024.',
+        '',
+        '[42] Y. Yan。自动转录。2024。',
+    ].join('\n');
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+    });
+
+    const citation = document.querySelector(
+        '.cm-mktero-html-table .cm-mktero-citation'
+    );
+    assert.equal(citation?.textContent, '41');
+    citation?.dispatchEvent(new dom.window.MouseEvent('mouseover', {
+        bubbles: true,
+    }));
+    assert.match(
+        document.querySelector('.mktero-citation-popup')?.textContent || '',
+        /Q\. Kong/
+    );
+
+    editor.destroy();
+    dom.window.close();
+});
+
 test('attaches a trailing MinerU table caption as the table header', () => {
     const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
         pretendToBeVisual: true,
@@ -4266,6 +4357,43 @@ test('keeps LaTeX superscript citations interactive instead of rendering math', 
         3
     );
     assert.equal(editor.getMarkdown(), markdown);
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('hovers LaTeX superscript citations with bare numbered references', () => {
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const markdown = [
+        '# Paper',
+        '',
+        '## INTRODUCTION',
+        '',
+        'WHO published guidance for 2018-2030 $^{1}$ and later evidence $^{2}$.',
+        '',
+        '## REFERENCES',
+        '',
+        '1 World Health Organization. Global action plan. 2018.',
+        '',
+        '2 World Health Organization. Global recommendations. 2020.',
+    ].join('\n');
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+    });
+
+    const citation = document.querySelector('.cm-mktero-citation');
+    assert.equal(citation?.textContent, '1');
+    citation?.dispatchEvent(new dom.window.MouseEvent('mouseover', {
+        bubbles: true,
+    }));
+    assert.match(
+        document.querySelector('.mktero-citation-popup')?.textContent || '',
+        /World Health Organization\. Global action plan\. 2018\./
+    );
 
     editor.destroy();
     dom.window.close();

--- a/test/markdown-citations.test.js
+++ b/test/markdown-citations.test.js
@@ -50,6 +50,147 @@ test('maps numeric citation tags and ranges to numbered references', () => {
     )));
 });
 
+test('maps superscript citations to bare numbered references', () => {
+    const markdown = [
+        '# Paper',
+        '',
+        '## INTRODUCTION',
+        '',
+        'WHO published guidance for 2018-2030 $^{1}$ and later evidence $^{2}$.',
+        '',
+        '## REFERENCES',
+        '',
+        '1 World Health Organization. Global action plan. 2018.',
+        '',
+        '2 World Health Organization. Global recommendations. 2020.',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.deepEqual(
+        result.references.map(reference => ({
+            id: reference.id,
+            number: reference.number,
+            text: reference.text,
+        })),
+        [{
+            id: 'number:1',
+            number: 1,
+            text: 'World Health Organization. Global action plan. 2018.',
+        }, {
+            id: 'number:2',
+            number: 2,
+            text: 'World Health Organization. Global recommendations. 2020.',
+        }]
+    );
+    assert.deepEqual(
+        result.citations.map(citation => ({
+            label: markdown.slice(citation.from, citation.to),
+            referenceIds: citation.referenceIds,
+        })),
+        [{ label: '1', referenceIds: ['number:1'] }, {
+            label: '2',
+            referenceIds: ['number:2'],
+        }]
+    );
+});
+
+test('skips a leading image before separating byline markers from citations', () => {
+    const markdown = [
+        '# Paper',
+        '',
+        '# Translated Paper',
+        '',
+        '![](cover.jpg)',
+        '',
+        'Alice Author $^{1,2}$, Bob Author $^{2}$',
+        '',
+        'For numbered affiliations see end of article.',
+        '',
+        '## ABSTRACT',
+        '',
+        'Summary without references.',
+        '',
+        '## INTRODUCTION',
+        '',
+        'WHO published the guidance $^{1}$.',
+        '',
+        '## Author affiliations',
+        '',
+        '$^{1}$ First Research Lab',
+        '',
+        '$^{2}$ Second Research Lab',
+        '',
+        '## REFERENCES',
+        '',
+        '1 World Health Organization. Global action plan. 2018.',
+        '',
+        '2 World Health Organization. Global recommendations. 2020.',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.deepEqual(
+        result.citations.map(citation => (
+            markdown.slice(citation.from, citation.to)
+        )),
+        ['1']
+    );
+    assert.ok(result.citations[0].from > markdown.indexOf('## INTRODUCTION'));
+});
+
+test('keeps year-leading reference paragraphs unnumbered', () => {
+    const markdown = [
+        '# Paper',
+        '',
+        'The reports describe the result.',
+        '',
+        '## References',
+        '',
+        '2020 report from the first working group.',
+        '',
+        '2021 follow-up from the second working group.',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.deepEqual(
+        result.references.map(reference => reference.number),
+        [null, null]
+    );
+    assert.deepEqual(result.citations, []);
+});
+
+test('maps citations with numbered bilingual reference headings', () => {
+    const markdown = [
+        '# Paper',
+        '',
+        'Prior work established the result [1].',
+        '',
+        '## 6. REFERENCES',
+        '',
+        '## 6. 参考文献',
+        '',
+        '[1] Alpha A. First paper. 2020.',
+        '',
+        '[1] Alpha A. 第一项研究。2020。',
+        '',
+        '[2] Beta B. Second paper. 2021.',
+        '',
+        '[2] Beta B. 第二项研究。2021。',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.deepEqual(
+        result.citations.map(citation => ({
+            label: markdown.slice(citation.from, citation.to),
+            referenceIds: citation.referenceIds,
+        })),
+        [{ label: '1', referenceIds: ['number:1'] }]
+    );
+});
+
 test('maps HTML superscript citation numbers and ranges to references', () => {
     const markdown = [
         '# Paper',


### PR DESCRIPTION
## Summary

- make citations inside rendered GFM and MinerU HTML tables interactive
- recognize numbered bilingual reference headings and bare numbered reference lists
- recover year-adjacent superscript citations while excluding author-affiliation markers
- handle leading cover images and bilingual H1 title pairs in front matter

## Reproductions

- `MUSIC-JEPA: LEARNING A WORLD MODEL OF SOUND FROM ACTION`
- `World Health Organization 2020 guidelines on physical activity and sedentary behaviour`

## Verification

- `npm run check`
- `npm test` (1196 tests passed)
- `npm run build`
- real WHO cache replay: 31 references and 39 citations in each source/translated view; 77 citations in comparison view