### PR TITLE
Fix split figure recognition in translated views

### DIFF
--- a/src/markdown/markdown-figure-references.js
+++ b/src/markdown/markdown-figure-references.js
@@ -6,12 +6,28 @@ import {
     normalizeReferenceIdentifier,
 } from './markdown-reference-analysis.js';
 
+const REFERENCE_SPACE_SOURCE = '[\\p{Zs}\\t]';
+const FIGURE_ENGLISH_LABEL_PREFIX_SOURCE = [
+    `fig[.．]${REFERENCE_SPACE_SOURCE}*`,
+    `fig${REFERENCE_SPACE_SOURCE}+`,
+    `figure${REFERENCE_SPACE_SOURCE}+`,
+].join('|');
+const FIGURE_LOCALIZED_LABEL_PREFIX_SOURCE =
+    `(?:图表|图)${REFERENCE_SPACE_SOURCE}*`;
+const FIGURE_LABEL_PREFIX_SOURCE = [
+    FIGURE_ENGLISH_LABEL_PREFIX_SOURCE,
+    FIGURE_LOCALIZED_LABEL_PREFIX_SOURCE,
+].join('|');
 const FIGURE_LABEL_PATTERN = new RegExp(
-    `^(?:fig\\.?|figure)[ \\t]+(${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE})`,
+    `^(?:${FIGURE_LABEL_PREFIX_SOURCE})`
+        + `(${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE})`,
     'iu'
 );
 const FIGURE_REFERENCE_PATTERN = new RegExp(
-    `\\b(?:fig\\.?|figure)[ \\t]+(${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE})\\b`,
+    `(?:\\b(?:${FIGURE_ENGLISH_LABEL_PREFIX_SOURCE})`
+        + `|${FIGURE_LOCALIZED_LABEL_PREFIX_SOURCE})`
+        + `(${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE})`
+        + `(?![A-Za-z0-9_])`,
     'giu'
 );
 

--- a/src/markdown/markdown-figures.js
+++ b/src/markdown/markdown-figures.js
@@ -1,6 +1,37 @@
 import { parseGFMTableRow } from './markdown-tables.js';
 
-const ACADEMIC_FIGURE_CAPTION_PATTERN = /^((?:(?:algorithm|chart|fig\.?|figure|scheme|table)[ \t]+(?:s?\d+[a-z]?|[ivxlcdm]+[a-z]?)[.:]|fig\.[ \t]+(?:s?\d+[a-z]?|[ivxlcdm]+[a-z]?)))[ \t]+(\S[\s\S]*)$/iu;
+const ACADEMIC_REFERENCE_SPACE_SOURCE = '[\\p{Zs}\\t]';
+const ACADEMIC_REFERENCE_IDENTIFIER_SOURCE =
+    '(?:s?\\d+[a-z]?|[ivxlcdm]+[a-z]?)';
+const ACADEMIC_FIGURE_CAPTION_PATTERNS = [
+    new RegExp(
+        `^((?:(?:algorithm|chart|fig\\.?|figure|scheme|table)`
+            + `${ACADEMIC_REFERENCE_SPACE_SOURCE}+`
+            + `${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE}[.:：。]`
+            + `|fig[.．]${ACADEMIC_REFERENCE_SPACE_SOURCE}+`
+            + `${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE}[.:：。]?))`
+            + `${ACADEMIC_REFERENCE_SPACE_SOURCE}+(\\S[\\s\\S]*)$`,
+        'iu'
+    ),
+    new RegExp(
+        `^((?:图表|图)${ACADEMIC_REFERENCE_SPACE_SOURCE}*`
+            + `${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE}[.:：。])`
+            + `${ACADEMIC_REFERENCE_SPACE_SOURCE}*(\\S[\\s\\S]*)$`,
+        'iu'
+    ),
+    new RegExp(
+        `^((?:fig[.．]${ACADEMIC_REFERENCE_SPACE_SOURCE}*`
+            + `${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE}[.:：。]?))`
+            + `${ACADEMIC_REFERENCE_SPACE_SOURCE}*(\\S[\\s\\S]*)$`,
+        'iu'
+    ),
+    new RegExp(
+        `^((?:图表|图)${ACADEMIC_REFERENCE_SPACE_SOURCE}*`
+            + `${ACADEMIC_REFERENCE_IDENTIFIER_SOURCE})`
+            + `${ACADEMIC_REFERENCE_SPACE_SOURCE}+(\\S[\\s\\S]*)$`,
+        'iu'
+    ),
+];
 const ACADEMIC_TABLE_CAPTION_PATTERN = /^(table[ \t]+(?:s?\d+[a-z]?|[ivxlcdm]+[a-z]?))([.:])?[ \t]+(\S[\s\S]*)$/iu;
 const ACADEMIC_TABLE_HEADING_PATTERN = /^ {0,3}#{1,6}[ \t]+(table[ \t]+(?:s?\d+[a-z]?|[ivxlcdm]+[a-z]?))([.:])?(?:[ \t]+#+)?[ \t]*$/iu;
 const ACADEMIC_TABLE_PLAIN_HEADING_PATTERN = /^ {0,3}(table[ \t]+(?:s?\d+[a-z]?|[ivxlcdm]+[a-z]?))([.:])?[ \t]*$/iu;
@@ -17,7 +48,9 @@ const MAX_PANEL_LABEL_LENGTH = 80;
 
 export function parseAcademicFigureCaption(value) {
     const text = String(value || '').trim();
-    const match = ACADEMIC_FIGURE_CAPTION_PATTERN.exec(text);
+    const match = ACADEMIC_FIGURE_CAPTION_PATTERNS
+        .map(pattern => pattern.exec(text))
+        .find(Boolean);
     if (!match) return null;
     return {
         text,
@@ -651,6 +684,13 @@ function trailingSharedPanelLabelGroup(lines, startIndex, blockedLines) {
         });
 
         index = nearbyLineIndex(lines, labelIndex + 1);
+        // Bilingual comparison inserts the translated axis label between panels.
+        while (index < lines.length && !blockedLines.has(index)
+            && !isMarkdownImageLine(lines[index].raw)) {
+            const repeatedPanelLabel = extractedPanelLabel(lines[index]);
+            if (!panelLabelsMayRepeat(panelLabel, repeatedPanelLabel)) break;
+            index = nearbyLineIndex(lines, index + 1);
+        }
         if (index < lines.length
             && !blockedLines.has(index)
             && isMarkdownImageLine(lines[index].raw)) {
@@ -671,7 +711,10 @@ function trailingSharedPanelLabelGroup(lines, startIndex, blockedLines) {
         return null;
     }
     const sharedLabel = images[0].panelLabel;
-    if (images.some(image => image.panelLabel !== sharedLabel)) return null;
+    if (images.some(image => !panelLabelsMatch(
+        image.panelLabel,
+        sharedLabel
+    ))) return null;
 
     return {
         from: lines[startIndex].from,
@@ -695,6 +738,34 @@ function extractedPanelLabel(line) {
         return null;
     }
     return text;
+}
+
+function panelLabelsMatch(left, right) {
+    const normalizedLeft = normalizePanelLabel(left);
+    return normalizedLeft !== ''
+        && normalizedLeft === normalizePanelLabel(right);
+}
+
+function panelLabelsMayRepeat(left, right) {
+    if (!right) return false;
+    if (panelLabelsMatch(left, right)) return true;
+    const candidate = String(right || '');
+    return hasNonASCIIWord(left) !== hasNonASCIIWord(candidate)
+        && !/[.!?。！？]$/u.test(candidate);
+}
+
+function hasNonASCIIWord(value) {
+    return [...String(value || '')].some(character => (
+        /\p{L}/u.test(character)
+        && character.codePointAt(0) > 0x7f
+    ));
+}
+
+function normalizePanelLabel(value) {
+    return String(value || '')
+        .normalize('NFKC')
+        .replace(/\s+/gu, '')
+        .toLowerCase();
 }
 
 function nearbyLineIndex(lines, index) {

--- a/test/figure-reference-editor.test.js
+++ b/test/figure-reference-editor.test.js
@@ -114,6 +114,43 @@ test('previews every panel in a referenced shared-caption figure', () => {
     dom.window.close();
 });
 
+test('keeps localized figure references interactive in translated and bilingual views', () => {
+    const translated = [
+        '尽管PPG和ABP信号具有相似的形状，如图1所示。',
+        '',
+        '![图1. PPG和ABP信号](images/figure.png)',
+    ].join('\n');
+    const bilingual = [
+        'Although the PPG and ABP signals are similar, as shown in Fig. 1.',
+        '',
+        '尽管PPG和ABP信号具有相似的形状，如图1所示。',
+        '',
+        '![Figure 1. PPG and ABP signals](images/figure.png)',
+    ].join('\n');
+
+    for (const [markdown, expected] of [
+        [translated, 1],
+        [bilingual, 2],
+    ]) {
+        const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+            pretendToBeVisual: true,
+        });
+        const { document } = dom.window;
+        const editor = createInlineMarkdownEditor({
+            parent: document.querySelector('#editor'),
+            initialMarkdown: markdown,
+            resolveImageURL: path => `blob:mktero-${path}`,
+        });
+
+        assert.equal(
+            document.querySelectorAll('.cm-mktero-figure-reference').length,
+            expected
+        );
+        editor.destroy();
+        dom.window.close();
+    }
+});
+
 test('jumps to and highlights a clicked figure reference for three seconds', () => {
     const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
         pretendToBeVisual: true,

--- a/test/markdown-figure-references.test.js
+++ b/test/markdown-figure-references.test.js
@@ -159,6 +159,88 @@ test('maps a reference to one composite image with a trailing panel label', () =
     )), ['Figure 3']);
 });
 
+test('maps localized figure labels and Unicode spacing in translated prose', () => {
+    const markdown = [
+        '尽管PPG和ABP信号具有相似的形状，如图1所示，',
+        '但直接评估SBP和DBP值并非易事；另见Fig.\u00a01。',
+        '',
+        '![图 1. PPG和ABP信号](images/figure.png)',
+    ].join('\n');
+
+    const result = analyzeMarkdownFigureReferences(markdown);
+
+    assert.deepEqual(result.targets.map(target => ({
+        id: target.id,
+        label: target.label,
+    })), [{
+        id: 'figure:1',
+        label: '图 1.',
+    }]);
+    assert.deepEqual(result.references.map(reference => ({
+        text: markdown.slice(reference.from, reference.to),
+        targetId: reference.targetId,
+    })), [{
+        text: '图1',
+        targetId: 'figure:1',
+    }, {
+        text: 'Fig.\u00a01',
+        targetId: 'figure:1',
+    }]);
+});
+
+test('keeps split Figure 1 targets in translated and bilingual paper views', () => {
+    const firstPanel = 'images/75036a1c04fe5b273b8dae9f4d121fa16efdc33d04dc66f46b71b575d22daf61.jpg';
+    const secondPanel = 'images/0c74f3058b21ed0e804b59e8cfa7f9438e364f637e7546c0f4751085aa522fde.jpg';
+    const source = [
+        'The right side of Fig. 1 shows an example ABP waveform.',
+        '',
+        'Although the PPG and ABP signals share a similar shape, as shown in Fig. 1.',
+        '',
+        `![](${firstPanel})  `,
+        'Time (s)',
+        '',
+        `![](${secondPanel})  `,
+        'Time (s)  ',
+        'Fig. 1. SBP and DBP estimation from PPG (left) and ABP (right) signals.',
+    ].join('\n');
+    const translated = [
+        'Fig. 1 的右侧展示了一个动脉血压波形示例。',
+        '',
+        '尽管PPG和ABP信号具有相似的形状，如Fig. 1所示。',
+        '',
+        `![](${firstPanel})  `,
+        '时间（秒）',
+        '',
+        `![](${secondPanel})  `,
+        '时间 (秒)  ',
+        'Fig. 1. 基于PPG（左）和ABP（右）信号的SBP与DBP估计。',
+    ].join('\n');
+    const bilingual = [
+        'The right side of Fig. 1 shows an example ABP waveform.',
+        '',
+        'Fig. 1 的右侧展示了一个动脉血压波形示例。',
+        '',
+        `![](${firstPanel})  `,
+        'Time (s)',
+        '',
+        '时间（秒）',
+        '',
+        `![](${secondPanel})  `,
+        'Time (s)  ',
+        'Fig. 1. SBP and DBP estimation from PPG (left) and ABP (right) signals.',
+        '时间 (秒)  ',
+        'Fig. 1. 基于PPG（左）和ABP（右）信号的SBP与DBP估计。',
+    ].join('\n');
+
+    for (const markdown of [source, translated, bilingual]) {
+        const result = analyzeMarkdownFigureReferences(markdown);
+        assert.deepEqual(result.targets.map(target => target.id), ['figure:1']);
+        assert.ok(result.references.some(reference => (
+            markdown.slice(reference.from, reference.to).includes('Fig. 1')
+        )));
+    }
+});
+
 test('ignores figure references in code and links and rejects duplicate labels', () => {
     const markdown = [
         '`Figure 3` is an example token.',


### PR DESCRIPTION
## Summary

- Fixes Figure 1 recognition for split multi-panel figures in translated and bilingual Markdown views.
- Normalizes Unicode spacing and compatibility punctuation in panel labels.
- Handles translated panel-label lines inserted between source panels in bilingual comparison output.
- Adds regression coverage using the Tiny Spiking Neural Network paper Figure 1 image paths and captions.

## Verification

- `npm run check`
- `npm test` (1199 passed)
- `npm run build`
- Version remains `0.3.2`.