### PR TITLE
docs: refresh project README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,46 +7,66 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Zotero](https://img.shields.io/badge/Zotero-7%20%7C%208%20%7C%209-cc2936.svg)](https://www.zotero.org/)
 
-[Product page](https://tenglvjun.github.io/mktero/) · [Download](https://github.com/tenglvjun/mktero/releases/latest) · [Discussions](https://github.com/tenglvjun/mktero/discussions)
+**Read Zotero PDFs as source-linked Markdown.**
 
-Mktero is a source-linked reflow reader for Zotero 7, 8, and 9. It converts a
-local PDF with MinerU, then opens the resulting Markdown, formulas, tables,
-figures, citations, and annotations in a reading-first Zotero tab. An optional
-correction mode lets you fix recognition errors without changing the immutable
-MinerU result, while optional AI translation can translate the full article in
-bounded concurrent Markdown batches and switch between original, translated, and
-continuous block-level bilingual reading.
+Mktero is a restartless Zotero extension for Zotero 7, 8, and 9. It sends a
+local PDF to [MinerU](https://mineru.net/) when needed, then opens the
+resulting Markdown, formulas, tables, figures, citations, and annotations in a
+temporary, reading-first Zotero tab. A content-addressed local cache avoids
+repeating conversions for the same PDF.
 
 ![Mktero converting, reading, and annotating an academic PDF in Zotero](./docs/assets/mktero-demo.gif)
 
-Read complex papers as a continuous document, annotate them from either view,
-and return to the original PDF whenever you need to verify the evidence.
-
 > [!IMPORTANT]
-> Mktero is currently in beta. On a cache miss, it uploads the complete PDF to
-> MinerU for conversion. A MinerU API Token is required. See
-> [Privacy and data handling](#privacy-and-data-handling) before using Mktero
-> with sensitive documents. AI translation separately sends protected Markdown
-> batches to the provider you configure, with up to five requests active at
-> once. After repeated placeholder-integrity failures, one final request sends
-> only the affected block's ordinary text segments.
+> Mktero is in beta. On a cache miss, the complete PDF is uploaded to MinerU,
+> so a MinerU API Token is required. Optional AI translation sends protected
+> Markdown batches to the provider configured by you. Review [Privacy and data
+> handling](#privacy-and-data-handling) before processing sensitive documents.
+
+Useful links: [Product page](https://tenglvjun.github.io/mktero/) ·
+[Download](https://github.com/tenglvjun/mktero/releases/latest) ·
+[Discussions](https://github.com/tenglvjun/mktero/discussions) ·
+[Issues](https://github.com/tenglvjun/mktero/issues)
+
+## Features
+
+- Reflow OCR output, multi-column text, formulas, tables, figures, lists, and
+  code into a continuous academic reading document.
+- Keep reliable page and region mappings so text, formulas, tables, and figures
+  can jump back to their PDF source.
+- Preview citations, author affiliations, figures, and tables without losing
+  the current reading position.
+- Display Zotero PDF highlights and underlines in Markdown, and create,
+  recolor, comment on, or delete annotations.
+- Correct recognition errors in existing paragraphs, headings, and GFM table
+  cells without modifying the immutable MinerU result. Corrections can be
+  reviewed, restored, or removed.
+- Translate a complete article through a configured Vercel AI SDK provider and
+  switch between Original, Translation, and continuous Bilingual reading.
+- Explore direct reference relationships among papers already in the current
+  Zotero library, using cache-first refreshes from Semantic Scholar,
+  OpenCitations, and OpenAlex when identifiers are available.
+- Save a portable Zotero snapshot containing HTML, Markdown, source maps, and
+  embedded figures.
+- Follow Zotero's English or Simplified Chinese display language; other locales
+  fall back to English.
 
 ## Quick start
 
 ### Requirements
 
 - Desktop Zotero `7.0` through `9.0.*`
-- A PDF attachment available as a local file
+- A PDF attachment downloaded and available as a local file
 - A [MinerU API Token](https://mineru.net/apiManage/token)
 - Network access to the MinerU API
 
-File-size, page-count, quota, and service-availability limits are controlled by
-MinerU. Refer to the [MinerU API documentation](https://mineru.net/apiManage/docs)
-for current limits.
+MinerU controls file-size, page-count, quota, and service-availability limits.
+See the [MinerU API documentation](https://mineru.net/apiManage/docs) for the
+current limits.
 
 ### Install
 
-1. Download `mktero-0.3.2.xpi` from
+1. Download the latest `mktero-<version>.xpi` from
    [GitHub Releases](https://github.com/tenglvjun/mktero/releases/latest).
 2. In Zotero, open `Tools -> Plugins`.
 3. Open the gear menu and choose `Install Add-on From File...`.
@@ -59,253 +79,89 @@ prereleases are not offered as automatic updates.
 
 Open `Settings -> Mktero` after installation.
 
-| Setting | Default | Purpose |
+| Setting | Required | Purpose |
 | --- | --- | --- |
-| API Token | Empty | Required when a conversion is not available locally |
-| Semantic Scholar API Key | Empty | Optional; anonymous citation graph requests remain supported |
-| OpenAlex API Key | Empty | Optional; anonymous citation graph requests remain supported |
-| OpenCitations Access Token | Empty | Optional; anonymous citation graph requests remain supported |
-| Body text font | System serif | Choose System serif, Georgia, Cambria, or Times New Roman |
-| Body text size | 18 px | Adjust Markdown and snapshot text from 16 to 22 px while keeping a wide, stable reading column |
-| Reuse conversion results | On | Reuse results for the same PDF content and parser profile |
-| Enable AI features | Off | Allow Markdown translation through the configured model service |
-| Stream responses | On | Stream each Markdown batch response; turn off to wait for each batch to finish |
-| AI base URL / API Key / provider / protocol / model | OpenAI Responses / empty model | Route AI calls through Vercel AI SDK Core to a hosted provider or loopback model server |
-| Translation language | Simplified Chinese | Choose Simplified/Traditional Chinese, Japanese, Korean, Spanish, French, or Brazilian Portuguese; English is excluded because source papers are assumed to be English |
-| Request timeout | 600,000 ms | Allow up to one hour for each batch request |
-| Maximum output tokens | Automatic (0) | Let the provider choose by default, or allow up to 262,144 tokens when the selected model supports it |
+| MinerU API Token | Yes for a cache miss | Upload and convert PDFs with MinerU |
+| AI features and provider settings | Optional | Translate Markdown through a hosted or loopback model service |
+| Translation language | Optional | Choose Simplified/Traditional Chinese, Japanese, Korean, Spanish, French, or Brazilian Portuguese |
+| Citation provider credentials | Optional | Increase limits for Semantic Scholar, OpenAlex, or OpenCitations; anonymous requests remain supported |
+| Body text font and size | Optional | Choose the reading font and a 16–22 px body size |
+| Reuse conversion results | Optional | Reuse results for the same PDF content and parser profile |
 
-The Mktero settings pane uses an aligned two-column layout for labels and
-controls, keeps Zotero's native select affordance, and uses explicit
-contrasting controls so configured values remain legible in Zotero's light and
-dark themes.
+Credentials are stored as ordinary, unencrypted preferences in the active
+Zotero profile. Use `Test connection` to validate an AI endpoint before
+translating.
 
-The MinerU API Token, citation provider credentials, and AI API Key are stored
-unencrypted as normal preferences in the active Zotero profile. Use
-`Test connection` to validate the current AI endpoint, key, and model before
-translating. This probe only requires a successful provider response; a
-reasoning-only response without visible text is sufficient.
+### Open a PDF
 
-### Open and read a PDF
+1. Open a PDF in Zotero and click the Mktero file icon in the reader toolbar, or
+   right-click a PDF or library item and choose `Read as Markdown with Mktero`.
+2. Follow the upload, conversion, and download progress in the temporary Mktero
+   tab. A valid cache entry skips the remote conversion.
+3. Use the outline, citations, figure/table previews, source links, and Zotero
+   notes panel to navigate the document.
+4. Use the reader toolbar to adjust typography, switch reading mode, translate,
+   correct recognition errors, or save a snapshot.
 
-1. Open a PDF and select the Mktero file icon in the reader toolbar, or
-   right-click one PDF or one library item and choose
-   `Read as Markdown with Mktero`.
-2. Mktero opens a temporary tab and reports upload, conversion, and download
-   progress. A valid cache entry skips the remote conversion.
-3. Use the outline, citation and figure previews, source links, and Zotero notes
-   panel to navigate the document.
-   When a citation jumps to its full reference, use the left-arrow button in the
-   toolbar or `Alt+Left` (`Command+[` on macOS) to return to the citation.
-4. Use the fixed toolbar above the Markdown body to change text size and font,
-   select a reading mode, or translate the article. Self-describing size and
-   font controls omit redundant visible labels, while retaining accessible
-   names. The toolbar uses compact, even spacing, with in-flight progress
-   condensed onto the main toolbar row at normal reader widths and the
-   translation action separated from reading mode. Once a translation is
-   available, its reading-mode tab displays the target language directly
-   instead of repeating that language in a separate label. Select that tab to
-   open a language menu: complete translations switch immediately, while
-   incomplete or untranslated languages continue or start translation when
-   selected. Simplified Chinese,
-   Traditional Chinese, Japanese, and Korean translated text automatically use
-   language-aware academic serif fallbacks. In Translation mode, the font
-   picker changes to academic fonts for the translation language; Original and
-   Bilingual modes keep the source-font picker.
-   The More menu contains `Manage corrections`, `Retranslate document`,
-   `Reparse PDF`, and `Save snapshot` when those actions are available.
+Mktero tabs are session-only and are not restored after Zotero restarts. Closing
+the tab or shutting down the extension cancels active conversion and
+translation requests.
 
-Reparsing uploads the PDF again and may consume MinerU quota. The current
-Markdown remains readable until a replacement is ready. Mktero tabs are
-session-only and are not restored after Zotero restarts.
+## Reading and annotation workflows
 
-### Explore the library citation graph
+### Source-aware reading
 
-Open a paper's Markdown reader and click the floating network button, or use
-the network button in the PDF reader toolbar. The citation graph opens in a
-modal dialog and focuses the current paper. It contains only that paper and
-the papers it directly references when those references can be matched to
-items in the current Zotero library. Papers that cite the current paper are
-not included yet, and no other library papers are shown.
-
-For a paper with a DOI, Mktero requests its references from Semantic Scholar,
-OpenCitations, and OpenAlex concurrently. For a paper that has only an arXiv
-identifier, Mktero uses Semantic Scholar. Cached provider results appear
-immediately, then each provider completion updates the graph independently.
-The refresh ends after six seconds; one failed provider does not discard data
-from the others, and a provider is paused for five minutes after two
-consecutive failed refreshes.
-
-Mktero sends only DOI and arXiv identifiers and optional provider credentials,
-never PDFs, Markdown, titles, notes, annotations, local paths, Zotero keys, or
-complete item records. OpenAlex receives DOI-only batches for the focused paper
-and local matching candidates; OpenAlex IDs returned by the service remain
-local. References are matched to Zotero papers only by a unique normalized DOI
-or arXiv identifier, never by title. Duplicate relationships are merged while
-retaining their provider provenance. Papers without a reliable identifier stay
-isolated. Search, the All/Connected filter, and the accessible References list
-can focus a paper; double-clicking a node or choosing `Open in Zotero` opens its
-PDF when available and otherwise selects the Zotero item. Clearing Mktero's
-local cache also removes cached citation records.
+MinerU content mappings connect Markdown blocks to physical PDF pages and
+regions. Source links and source-aware copy use those mappings when they are
+reliable; Mktero does not guess a location when a match is ambiguous. Markdown
+is rendered in an isolated shadow root with a restricted link and image policy.
 
 ### Correct recognition errors
 
-Double-click a paragraph, heading, or GFM table cell directly from the normal
-reading view. Press `Enter` or `F2` after focusing an editable block as a
-keyboard alternative. Text and table changes use the same explicit action bar:
-the Save button is enabled only after a change, while Save, Cancel, and
-`Ctrl/Command+Enter` or `Escape` provide matching commit and cancel behavior.
-Leaving a table cell does not save it automatically. If saving fails, the
-current input stays in place so you can retry or cancel. The same action bar
-can delete a whole paragraph or heading without removing it one character at a
-time; a short Undo deletion prompt is shown after a successful deletion.
+Double-click an existing paragraph, heading, or GFM table cell to edit it, then
+save or cancel explicitly. Existing paragraphs and headings can also be
+deleted and restored from `Manage corrections`. Corrections are stored
+separately from the conversion cache and are tied to the PDF content and MinerU
+parser profile. They cannot insert or reorder blocks, add images, or add raw
+HTML.
 
-Choose `Manage corrections` from the More menu to review corrected blocks and
-restore an individual deletion. Deleted blocks appear as compact, reversible
-placeholders only in this management mode. Normal reading hides correction
-markers and collapses the gaps left by deleted blocks, while the More menu can
-restore all corrections.
+### Annotate from Markdown
 
-Corrections are tied to the current PDF content and MinerU parser profile. They
-are stored separately from the conversion cache, so clearing or expiring the
-cache does not remove them. `Reparse PDF` asks before permanently deleting
-corrections; this MVP does not merge corrections into a newly parsed result.
-Editing is intentionally limited to existing paragraphs, headings, and GFM
-table cells: existing paragraphs and headings can be removed, but blocks cannot
-be inserted or reordered, and corrections cannot add images or raw HTML.
+Existing Zotero text highlights and underlines are loaded when a document opens.
+Selecting Markdown text can create a local annotation immediately; Mktero then
+creates the corresponding Zotero annotation only when the local PDF text index
+can identify one reliable match. Repeated or ambiguous text remains local and
+can be retried instead of receiving a guessed PDF position.
 
-If Actions & Tags for Zotero is installed, Mktero integrates with compatible
-`openFile` and `closeTab` rules for sessions it owns without duplicating native
-reader actions.
+### Translate with AI
 
-### Translate a Markdown article with AI
+AI translation is always opt-in and never rewrites the source Markdown. Mktero
+groups the article into bounded Markdown batches, protects formulas, citations,
+links, code, images, and structural placeholders, and runs at most five
+requests concurrently. Choose `Original`, `Translation`, or `Bilingual` in
+the reader. Translations are cached independently by source content, provider,
+protocol, model, language, and prompt version, so partial work can resume.
 
-Configure and enable AI translation in `Settings -> Mktero`, then select
-`Translate document` in a Markdown tab's toolbar. Mktero groups the protected
-Markdown document at top-level H1 headings, divides each group into batches of
-up to eight blocks and about 2,000 estimated source tokens, and keeps up to five
-batch requests active. Responses are matched by block ID and merged in source
-order. Missing or invalid blocks are retried individually up to two times.
-If the final retry changes protected placeholders, Mktero makes one fallback
-request containing only the affected block's ordinary text segments, keyed by
-stable segment IDs. Formulas, citations, figure and table labels, and internal
-placeholder tokens are not included in that request. Mktero then reassembles
-the translated segments with the original protected content locally and runs
-the same structural, ordering, and output-size validation before accepting it.
-Blocks that still fail keep their source text and leave the translation in a
-retryable partial state. Reference sections are kept unchanged. Code, images,
-standalone formulas, link definitions, raw HTML, URLs, inline code, and
-interactive citations, superscripts, figure references, table references, and
-their target labels are replaced with protected placeholders before each
-request and restored only after the response passes structural validation.
-Restored numeric citations and inline formulas remain rendered when adjacent
-to translated CJK prose. Caption descriptions and surrounding prose remain
-translatable.
-Translation is always an explicit action and never rewrites the source Markdown
-or becomes part of a saved snapshot. Streaming is enabled by default for
-provider transport. While translation is running, the toolbar
-action shows a loading spinner, target language, translated block count, and
-percentage. Before any complete translation exists, the action remains
-available as `Cancel translation`; after one exists, cancellation moves into
-the translation-language menu so the current document remains readable.
-Existing original, translated, and bilingual views remain
-available while a retry runs in the background. The reader switches to the
-translated document after all requested batches settle. An incomplete result remains
-visible, marks every source-text fallback, and supports retrying all incomplete
-translation from the toolbar or jumping between failures. The failure navigator
-shows the current position and total, for example `1/3`.
-Connection tests always use a short non-streaming request.
+Mktero includes adapters for OpenAI, Anthropic, Google Gemini, DeepSeek,
+Alibaba Cloud Model Studio, Moonshot/Kimi, MiniMax, and custom OpenAI-compatible
+or Open Responses services through Vercel AI SDK Core. Remote endpoints must
+use HTTPS; loopback services such as Ollama or LM Studio may use HTTP.
 
-After translation, use the reading-mode selector to choose `Original`,
-`Translation`, or `Bilingual`. Original is the default whenever a document
-opens. Bilingual presents one continuous reading document: every source
-heading, paragraph, list, blockquote, or table is immediately followed by its
-translation. Translated blocks use a restrained left rule, indentation, and
-lower heading emphasis, while the outline contains only source headings. The
-toolbar always shows the translation language, adds progress while work is in
-flight, and shows only the untranslated count for a partial result. A complete
-result omits the redundant `N/N` count. The single reading surface remains
-usable when Zotero's side panels reduce the available document width. In
-Bilingual mode, PDF annotations, source navigation, sourced copy, and new
-Markdown annotations remain available on source blocks; translated blocks do
-not expose source-only actions. Bilingual blocks remain visually stable while
-reading and do not expose per-block translation actions. `Retranslate document`
-in the More menu regenerates the visible language with the current provider and
-model settings.
+### Explore the citation graph
 
-All AI calls pass through Vercel AI SDK Core. Mktero includes adapters for
-OpenAI, Anthropic, Google Gemini, DeepSeek, Alibaba Cloud Model Studio,
-Moonshot/Kimi, and MiniMax, plus a custom service option. The selected protocol
-determines whether the adapter uses OpenAI Responses, OpenAI Chat Completions,
-Open Responses, Anthropic Messages, or Google Generative Language. Only valid
-provider/protocol combinations are selectable. Model availability and IDs
-remain provider-specific. Remote endpoints must use HTTPS. Loopback servers
-such as Ollama or LM Studio may use HTTP and may omit the API Key when
-authentication is disabled.
+The citation graph contains the focused paper and direct references that can be
+matched to items already in the current Zotero library. DOI and arXiv
+identifiers are queried concurrently from Semantic Scholar, OpenCitations, and
+OpenAlex when supported. Matching uses a unique normalized identifier, never a
+title, and provider metadata stays local.
 
-The translated blocks are stored inside the corresponding PDF Markdown cache
-entry and keyed by source content, provider, protocol, model, target language,
-and prompt version. Each target language keeps an independent result. The
-language configured in Settings is only the default for the first translation
-of a document; changing it never replaces, cancels, or starts translation in an
-open Markdown tab. Once any complete translation exists, the primary
-translation action stays hidden. The translated reading-mode tab opens a menu
-containing every supported language for the current document and model
-configuration. Choosing a complete language switches the cached translation
-without another request. Choosing an incomplete or untranslated language
-continues or starts that language's translation without changing the default
-in Settings. Partial caches resume their missing blocks instead of being
-treated as complete. The translated and bilingual reading documents are
-rebuilt from the cached blocks in source order, so presentation updates do not
-require another AI request. Clearing, replacing, or evicting that Markdown
-cache entry removes all of its translations. Lists, blockquotes, and GFM tables
-are translated; images, code, standalone formulas, link definitions, raw HTML,
-and interactive academic reference labels are preserved. Closing the
-tab, reparsing, editing the Markdown, or shutting down Mktero cancels active
-translation requests.
+### Save a portable snapshot
 
-### Save a portable Zotero snapshot
-
-Choose `Save snapshot` to create a dedicated `Mktero Markdown Snapshot` Note
-under the PDF's parent item. Mktero stores portable HTML in the Note, figures as
-embedded image attachments, and the original Markdown and source map as related
-attachments. Zotero can then sync those items normally.
-
-Desktop clients with Mktero prefer the synchronized Markdown source. Other
-clients can read the portable HTML Note. Mktero refuses to silently overwrite a
-snapshot Note that the user has edited. A standalone PDF without a parent
-library item cannot save a snapshot.
-
-## Highlights
-
-- Reflows OCR output, multi-column text, formulas, tables, figures, lists, and
-  code into a continuous reading document.
-- Corrects recognition errors in existing paragraphs, headings, and GFM table
-  cells, including removing spurious paragraphs or headings, while preserving
-  the original MinerU Markdown and correction history.
-- Translates full Markdown articles through a configured Vercel AI SDK provider
-  and offers original, translated, and continuous block-level bilingual reading.
-- Uses paper-oriented typography with STIX/Noto serif fallbacks, and applies
-  asynchronous Shiki syntax highlighting, language labels, and code copying to
-  supported fenced code blocks.
-- Restores adjacent academic table and figure captions when MinerU places a
-  caption before or after a table, assigns a table caption to the next image,
-  or extracts a composite figure's panel label separately from its caption.
-- Preserves reliable page and region mappings so text, formulas, tables, and
-  figures can return to their PDF source.
-- Previews citations, author affiliations, figures, and tables without leaving
-  the reading position.
-- Displays Zotero PDF highlights and underlines in Markdown and lets you create,
-  recolor, comment on, and delete annotations.
-- Copies selected content with the paper title, physical PDF pages, and Zotero
-  backlinks when reliable source information is available.
-- Keeps a content-addressed local cache and resumes recently uploaded MinerU
-  tasks without uploading the same PDF again.
-- Shows the focused paper's directed reference relationships only among papers
-  already in the current Zotero library, with cache-first concurrent refreshes
-  from Semantic Scholar, OpenCitations, and OpenAlex when supported.
-- Follows Zotero's display language for English and Simplified Chinese; other
-  locales fall back to English.
+`Save snapshot` creates a dedicated `Mktero Markdown Snapshot` Note under the
+PDF's parent item. The Note contains portable HTML; figures are embedded image
+attachments; the original Markdown and source map are related attachments.
+Mktero refuses to silently overwrite a snapshot Note that you edited. A
+standalone PDF without a parent library item cannot save a snapshot.
 
 ## How it works
 
@@ -322,148 +178,70 @@ Local content cache             Safe normalization/rendering
                            Reading-first Mktero tab in Zotero
 ```
 
-Mktero treats PDFs, conversion results, archives, image paths, API responses,
-and preferences as untrusted input. Markdown is normalized and rendered inside
-an isolated shadow root; it is not inserted as arbitrary HTML into Zotero's
-chrome document.
-
-## Annotations and source links
-
-Existing Zotero text highlights and underlines are loaded fresh whenever a
-document opens. Selecting ordinary Markdown text can create a local highlight
-or note immediately. Mktero then uses a local PDF.js text index to create the
-matching Zotero annotation only when the text can be located reliably. Failed
-or ambiguous matches stay visible locally and can be retried; Mktero does not
-guess a PDF position. When selected text repeats, Mktero compares up to 80
-visible characters before and after the selection to distinguish candidates,
-while the resulting PDF highlight still covers only the selected text. If the
-surroundings do not identify one clear candidate, the match remains ambiguous.
-Context disambiguation requires the local PDF.js index; if that index is
-unavailable, the Zotero Reader fallback keeps repeated selections ambiguous
-instead of expanding the PDF highlight. Matching tolerates common extraction
-differences in citation superscripts, statistical exponents, LaTeX relational
-operators including those immediately after an opening delimiter, misdecoded
-temperature degree signs, escaped Markdown percentages, and words split across
-PDF lines. Lexical hyphens and discretionary line-end hyphens can be resolved
-independently within one selection. Misplaced ligatures or numeric prefix
-symbols within a visual line are also normalized.
-Misencoded plus-minus signs are handled only in long, uniquely matched
-selections.
-
-When loading an existing Zotero PDF annotation into Markdown, Mktero uses its
-page and sort index to locate the exact PDF occurrence and compares up to 80
-characters on either side with the remaining Markdown candidates after any
-reliable page filtering. The Markdown overlay remains limited to the original
-annotation text. If the PDF index,
-source offset, or surrounding text cannot identify exactly one candidate, the
-annotation remains ambiguous instead of being placed on a guessed occurrence.
-
-Reliable MinerU content mappings also enable source navigation and
-source-aware copying. Page hints narrow annotation matching to the correct
-physical PDF page, while mapped region coordinates are used only for source
-navigation, not as guessed annotation rectangles.
+PDFs, MinerU results, archives, image paths, API responses, and preferences are
+treated as untrusted input. Archives and Markdown are checked against resource
+budgets, archive paths are normalized, remote Markdown images are not loaded,
+and raw HTML is escaped or sanitized before rendering.
 
 ## Privacy and data handling
 
-| Data | Where it goes | Zotero sync |
+| Data | Sent to or stored in | Zotero sync |
 | --- | --- | --- |
-| Complete PDF on a cache miss | Uploaded to MinerU | Not by Mktero |
-| API Token | Active Zotero profile, unencrypted | No |
-| AI API Key | Active Zotero profile, unencrypted | No |
-| Semantic Scholar API Key | Active Zotero profile, unencrypted | No |
-| OpenAlex API Key | Active Zotero profile, unencrypted | No |
-| OpenCitations Access Token | Active Zotero profile, unencrypted | No |
-| Focused DOI or arXiv identifier | Semantic Scholar | Not by Mktero |
-| Focused DOI | OpenCitations | Not by Mktero |
-| Focused and local candidate DOI identifiers | OpenAlex | Not by Mktero |
-| Protected translatable Markdown batches, plus ordinary text segments used only after repeated placeholder-integrity failures | Configured AI provider | Not by Mktero |
-| Cached Markdown, figures, source maps, and PDF text indexes | Active Zotero profile, unencrypted | No |
-| Cached AI translations | Active Zotero profile, unencrypted | No |
-| Cached provider reference metadata and provenance | Active Zotero profile, unencrypted | No |
-| Pending MinerU task IDs and timestamps | Active Zotero profile, unencrypted | No |
-| Pending Markdown annotation records, including bounded surrounding text used for matching | Active Zotero profile, unencrypted until synchronized | No |
-| Corrected Markdown blocks and their base figures/source maps | Active Zotero profile, unencrypted | No |
-| Synchronized PDF annotations | Local Zotero library | According to Zotero settings |
-| Saved snapshot Note, HTML, Markdown, source map, and figures | Zotero items and attachments, unencrypted | According to Zotero settings |
+| Complete PDF on a cache miss | MinerU | Not by Mktero |
+| MinerU API Token and AI/provider credentials | Active Zotero profile, unencrypted | No |
+| Cached Markdown, figures, source maps, PDF indexes, corrections, and translations | Active Zotero profile, unencrypted | No |
+| Focused DOI/arXiv identifiers and provider-specific candidate DOI identifiers | Semantic Scholar, OpenCitations, or OpenAlex | Not by Mktero |
+| Protected Markdown translation batches | AI provider configured by you | Not by Mktero |
+| Zotero PDF annotations | Local Zotero library | According to Zotero settings |
+| Saved snapshot Note and attachments | Zotero items and attachments | According to Zotero settings |
 
-The local cache does not contain API Tokens, citation provider credentials, AI
-API Keys, or PDF annotation comments. PDF annotations and local PDF.js indexes
-are not sent to MinerU or the AI provider. Translation sends protected Markdown
-batches and translation instructions to the configured AI provider, with at
-most five requests active at once. If a block repeatedly fails
-placeholder-integrity validation, a final request sends only that block's
-ordinary text segments; protected formulas, citations, reference labels, and
-placeholder tokens remain local. Source-aware copy reads local item metadata
-and writes only the generated result to the system clipboard. Citation graph
-requests send only normalized DOI and arXiv identifiers plus the applicable
-credential to Semantic Scholar, OpenCitations, or OpenAlex. Cached reference
-metadata and provider provenance are local, unencrypted, and not synced by
-Zotero; no paper outside the current Zotero library becomes a graph node.
+Mktero does not send PDF annotations, local PDF.js indexes, Zotero notes,
+complete item records, local paths, or cached Markdown to MinerU or citation
+providers. Translation requests contain protected Markdown and instructions; if
+placeholder validation repeatedly fails, the final retry contains only the
+affected block's ordinary text segments. API Tokens, presigned URLs, PDF bytes,
+and authenticated responses are not written to logs.
 
-Correction data is kept outside the normal conversion cache under the active
-Zotero profile. Clearing the cache does not clear corrections. Corrections are
-local to this device unless they are included in a saved Zotero snapshot; a
-corrected snapshot carries an explicit provenance notice and correction count.
+Review the privacy policy of MinerU and any AI or citation provider you enable.
+Do not process confidential PDFs unless their data-handling terms are suitable
+for your use case.
 
-Pending-task records contain only MinerU task identifiers, Mktero data IDs, and
-upload timestamps. They do not contain the PDF, its filename or path, upload or
-download URLs, the API Token, or authenticated API responses.
+## Limitations
 
-Saved snapshots do not include the original PDF, the MinerU result archive, the
-API Token, or API responses. Their synchronization and storage quota are
-controlled by Zotero.
-
-## Security boundaries and current limitations
-
-- Markdown is read-only by default. Correction mode can replace the content of
-  existing paragraphs, headings, and GFM table cells, or remove an existing
-  paragraph or heading. It cannot otherwise change document structure, formulas,
-  images, or raw HTML. Annotation actions remain separate from Markdown
-  corrections.
-- AI translation is an optional cached reading layer. It never starts
-  automatically, modifies source Markdown, syncs through Zotero, or saves
-  translations into snapshots. Mktero requests non-reasoning generation to keep
-  translation responsive. If the selected model or Provider explicitly rejects
-  disabling reasoning, Mktero retries once with that Provider's default behavior.
-  Mktero does not expose a reasoning-effort setting.
-- Only local PDF attachments are supported. Missing or undownloaded files
-  cannot be converted.
-- Text annotations require extractable PDF text. A scanned PDF may convert via
-  OCR but still cannot produce precise Zotero highlight rectangles.
-- Mktero currently displays text highlights and underlines, not standalone
-  notes, image/area annotations, or ink annotations.
-- Source navigation requires the stable MinerU `*_content_list.json` format.
-  Older cache entries remain readable but may not have source links.
+- Only local PDF attachments are supported. A scanned PDF may convert through
+  OCR but still lacks the text layer needed for precise Zotero highlights.
+- Source navigation depends on the stable MinerU `*_content_list.json` format;
+  older cached results may remain readable without source links.
 - Navigation currently goes from Markdown to PDF. Reverse navigation is not
   implemented.
-- Markdown images resolve only supported GIF, JPEG, PNG, and WebP files from the
-  current result archive; remote Markdown images are not loaded.
+- Mktero displays text highlights and underlines, not standalone notes,
+  image/area annotations, or ink annotations.
+- Markdown images are limited to supported GIF, JPEG, PNG, and WebP files from
+  the current result archive. Remote images are blocked.
 - Links are restricted to `http`, `https`, `zotero`, and document fragments.
-- Raw HTML is escaped by default. Sanitized MinerU tables allow only a limited
-  set of tags and attributes.
-- Archives, Markdown, images, source maps, PDF indexes, and KaTeX rendering all
-  have local resource budgets and fail safely when limits are exceeded.
+- Markdown correction mode only edits or removes existing blocks; it cannot
+  change document structure, formulas, images, or raw HTML.
+- AI translation is an optional cached reading layer. It does not modify source
+  Markdown or get included in snapshots.
+- Archives, Markdown, images, source maps, PDF indexes, and KaTeX rendering have
+  local resource limits and fail safely when those limits are exceeded.
 
 ## Troubleshooting
 
 In Zotero, open `Help -> Debug Output Logging`, enable logging, reproduce the
-conversion, and filter the output for `Mktero:`. Useful stages include:
+problem, and filter for `Mktero:`. Confirm that the PDF is downloaded locally,
+the MinerU Token is valid, and the current network can reach MinerU. Logs do
+not contain API Tokens, presigned upload URLs, MinerU batch IDs, or PDF content.
 
-- `requesting a MinerU upload URL`
-- `uploading PDF to MinerU`
-- `PDF upload completed; MinerU is parsing`
-- `MinerU parsing finished; downloading the result`
-- `completed from local cache; MinerU upload skipped`
-- `completed from a resumed MinerU task`
-
-Logs do not contain API Tokens, presigned upload URLs, MinerU batch IDs, or PDF
-content. If conversion still fails, confirm that the attachment is available
-locally, the Token is valid, and MinerU is reachable from the current network.
+For a confirmed, reproducible bug, open a [GitHub Issue](https://github.com/tenglvjun/mktero/issues)
+with the Zotero and Mktero versions, operating system, PDF type, reproduction
+steps, expected behavior, and actual behavior. Never attach API Tokens, private
+PDFs, authenticated URLs, or local file paths.
 
 ## Development
 
-Use Node.js `24.15.0` from [`.node-version`](./.node-version). Node.js 25 is
-outside the supported dependency engine range.
+Use the Node.js version in [`.node-version`](./.node-version), currently
+`24.15.0`. Node.js 25 is outside the supported dependency range.
 
 ```bash
 npm ci
@@ -472,41 +250,21 @@ npm test
 npm run build
 ```
 
-The build creates the unpacked extension, a reproducible
-`build/mktero-0.3.2.xpi`, its SHA-256 checksum, and `build/updates.json`.
-Generated `build/` and `node_modules/` directories are ignored and must not be
-committed.
+Run one test while iterating with `node --test test/<name>.test.js`. The build
+creates the reproducible XPI, SHA-256 checksum, and `build/updates.json` under
+`build/`; `build/` and `node_modules/` are generated and ignored.
 
-Before creating the release tag, keep the versions in `manifest.json`,
-`package.json`, and `package-lock.json` consistent. Create and push the annotated
-tag with:
+Keep the versions in `manifest.json`, `package.json`, and `package-lock.json`
+consistent before tagging a release. See [AGENTS.md](./AGENTS.md) for the
+architecture, security invariants, and contribution checklist.
 
-```bash
-git tag v0.3.2 -m "Mktero 0.3.2"
-git push origin v0.3.2
-```
+## Contributing
 
-The release workflow checks the tag against `manifest.json` before publishing.
-Pushes and pull requests run the test, build, and CodeQL workflows without
-publishing a release.
-
-See [AGENTS.md](./AGENTS.md) for the repository architecture, coding rules,
-security invariants, and cross-file change checklist.
-
-## Feedback and contributing
-
-- Use [GitHub Discussions](https://github.com/tenglvjun/mktero/discussions) for
-  reading workflows, ideas, and beta feedback.
-- Use [GitHub Issues](https://github.com/tenglvjun/mktero/issues) for confirmed,
-  reproducible bugs.
-
-Include the Zotero and Mktero versions, operating system, PDF type,
-reproduction steps, expected behavior, and actual behavior. Never attach API
-Tokens, private PDFs, authenticated URLs, local file paths, or other sensitive
-information.
-
-Pull requests are welcome. Run the complete verification commands above and
-follow [AGENTS.md](./AGENTS.md) when changing runtime behavior.
+Pull requests are welcome. For ideas, reading workflows, and beta feedback, use
+[GitHub Discussions](https://github.com/tenglvjun/mktero/discussions). For
+changes to runtime behavior, run the complete verification commands above and
+include tests for the affected behavior. Please keep credentials, private PDFs,
+and other sensitive data out of issues, pull requests, and logs.
 
 ## License
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -7,28 +7,42 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](./LICENSE)
 [![Zotero](https://img.shields.io/badge/Zotero-7%20%7C%208%20%7C%209-cc2936.svg)](https://www.zotero.org/)
 
-[产品介绍页](https://tenglvjun.github.io/mktero/) · [下载最新版本](https://github.com/tenglvjun/mktero/releases/latest) · [参与讨论](https://github.com/tenglvjun/mktero/discussions)
+**在 Zotero 中以带来源链接的 Markdown 阅读 PDF。**
 
-Mktero 是一个适用于 Zotero 7、8 和 9 的来源关联重排阅读器。它通过 MinerU
-转换本地 PDF，并在阅读优先的 Zotero 标签页中展示 Markdown 正文、公式、表格、
-图片、学术引用和标注；可选的校对模式允许修正识别错误，同时保留不可变的 MinerU
-原始结果；可选的 AI 翻译会按一级标题分组并拆成受控批次并发翻译整篇文章，并在原文、译文和连续块级双语对照之间切换。
+Mktero 是适用于 Zotero 7、8 和 9 的无需重启扩展。需要时，它会将本地 PDF
+发送到 [MinerU](https://mineru.net/) 进行转换，再在临时的阅读优先 Zotero 标签页中
+打开 Markdown、公式、表格、图片、引用和标注。内容寻址的本地缓存会复用同一 PDF 的转换结果，避免重复处理。
 
 ![Mktero 在 Zotero 中转换、阅读和标注学术 PDF](./docs/assets/mktero-demo.gif)
 
-将复杂论文作为连续文档阅读，从任一视图进行标注，并随时返回原始 PDF 核验证据。
-
 > [!IMPORTANT]
-> Mktero 目前处于 Beta 阶段。缓存未命中时，完整 PDF 会上传到 MinerU 进行转换，
-> 因此需要 MinerU API Token。处理敏感文档前，请先阅读[缓存与隐私](#缓存与隐私)。
-> AI 翻译是独立的数据发送路径，会将正文拆成受控批次后发送给所配置的 Provider，最多同时执行 5 个请求。若占位符完整性连续校验失败，最后一次请求只发送受影响内容块中的普通文本片段。
+> Mktero 目前处于 Beta 阶段。缓存未命中时，完整 PDF 会上传到 MinerU，因此需要
+> MinerU API Token。可选的 AI 翻译会把受保护的 Markdown 批次发送给你配置的 Provider。
+> 处理敏感文档前，请阅读[数据与隐私](#数据与隐私)。
+
+常用链接：[产品介绍页](https://tenglvjun.github.io/mktero/) ·
+[下载最新版本](https://github.com/tenglvjun/mktero/releases/latest) ·
+[Discussions](https://github.com/tenglvjun/mktero/discussions) ·
+[Issues](https://github.com/tenglvjun/mktero/issues)
+
+## 核心能力
+
+- 将 OCR 结果、双栏正文、公式、表格、图片、列表和代码重排成连续的论文阅读文档。
+- 保留可靠的页码和区域映射，使正文、公式、表格和图片可以跳回 PDF 来源。
+- 在不丢失当前位置的情况下预览引用、作者单位、图片和表格。
+- 在 Markdown 中显示 Zotero PDF 高亮和下划线，并支持新建、编辑、改色、评论和删除标注。
+- 在不修改不可变 MinerU 结果的前提下，校对已有段落、标题和 GFM 表格单元格；校对内容可查看、恢复或删除。
+- 通过配置的 Vercel AI SDK Provider 翻译整篇文章，并在原文、译文和连续块级双语阅读之间切换。
+- 只在当前 Zotero 文库内展示可匹配的直接引用关系，并在支持时使用 Semantic Scholar、OpenCitations 和 OpenAlex 刷新数据。
+- 保存包含 HTML、Markdown、来源映射和内嵌图片的便携 Zotero 快照。
+- 界面跟随 Zotero 的英文或简体中文显示语言，其他语言回退为英文。
 
 ## 快速开始
 
 ### 使用要求
 
 - 桌面版 Zotero `7.0` 至 `9.0.*`
-- 可在本机访问的 PDF 附件
+- 已下载并可在本机访问的 PDF 附件
 - [MinerU API Token](https://mineru.net/apiManage/token)
 - 能够访问 MinerU API 的网络环境
 
@@ -38,9 +52,9 @@ Mktero 是一个适用于 Zotero 7、8 和 9 的来源关联重排阅读器。�
 ### 安装
 
 1. 从 [GitHub Releases](https://github.com/tenglvjun/mktero/releases/latest)
-   下载 `mktero-<version>.xpi`。
+   下载最新的 `mktero-<version>.xpi`。
 2. 在 Zotero 中打开 `工具 -> 插件`。
-3. 打开插件管理器右上角的齿轮菜单，选择 `Install Add-on From File...`。
+3. 打开齿轮菜单，选择 `Install Add-on From File...`。
 4. 选择 XPI 文件并按 Zotero 提示完成安装。
 
 正式 GitHub Release 可以通过 Zotero 自动更新；草稿和预发布版本不会成为自动更新目标。
@@ -49,161 +63,55 @@ Mktero 是一个适用于 Zotero 7、8 和 9 的来源关联重排阅读器。�
 
 安装后打开 `设置 -> Mktero`。
 
-| 设置 | 默认值 | 作用 |
+| 设置 | 是否必需 | 作用 |
 | --- | --- | --- |
-| API Token | 空 | 本地没有可用转换结果时必填 |
-| Semantic Scholar API Key | 空 | 可选；留空时仍可匿名获取引用图谱数据 |
-| Body text font | 系统衬线字体 | 可选系统衬线、Georgia、Cambria 或 Times New Roman |
-| Body text size | 18 px | 在 16–22 px 间调整 Markdown 和快照字号，同时保持宽且稳定的阅读版心 |
-| Reuse conversion results | 开启 | 复用相同 PDF 内容和解析配置对应的结果 |
-| 启用 AI 功能 | 关闭 | 通过配置的模型服务翻译 Markdown 文章（一级标题分组、受控批次、最多 5 个并发） |
-| 流式响应 | 开启 | 流式接收每个批次响应；关闭后等待每批响应结束 |
-| AI Base URL / API Key / 模型厂商 / 协议 / 模型 | OpenAI Responses / 模型为空 | 通过 Vercel AI SDK Core 连接托管 Provider 或回环地址上的本地模型服务 |
-| 翻译语言 | 简体中文 | 可选择简体中文、繁体中文、日文、韩文、西班牙语、法语或葡萄牙语（巴西）；默认论文原文为英文，因此不提供英文翻译 |
-| 请求超时 | 600,000 毫秒 | 单个 Markdown 批次请求最长可等待一小时 |
-| 最大输出 Token 数 | 自动（0） | 默认由 Provider 决定；所选模型支持时最高可设为 262,144 |
+| MinerU API Token | 缓存未命中时必需 | 使用 MinerU 上传并转换 PDF |
+| AI 功能和 Provider 设置 | 可选 | 通过托管或本地回环模型服务翻译 Markdown |
+| 翻译语言 | 可选 | 简体/繁体中文、日文、韩文、西班牙语、法语或巴西葡萄牙语 |
+| 引用 Provider 凭据 | 可选 | 提高 Semantic Scholar、OpenAlex 或 OpenCitations 的请求额度；也支持匿名请求 |
+| 正文字体和字号 | 可选 | 选择阅读字体，并在 16–22 px 间调整字号 |
+| 复用转换结果 | 可选 | 复用相同 PDF 内容和解析配置对应的结果 |
 
-MinerU API Token、Semantic Scholar API Key 和 AI API Key 都会作为普通首选项未加密地保存在当前 Zotero
-配置文件中。开始翻译前，可使用“测试连接”验证当前 AI 地址、Key、模型厂商、协议和模型。
-该探测只要求 Provider 成功返回响应；只有 reasoning、没有可见正文的响应也会判定为成功。
+凭据会作为普通的未加密首选项存储在当前 Zotero 配置文件中。开始翻译前，可以使用
+`测试连接`验证 AI 地址。
 
-### 打开和阅读 PDF
+### 打开 PDF
 
-1. 打开 PDF 后点击阅读器工具栏中的 Mktero 文件图标；也可以右键单个 PDF 或文库
-   条目，选择 `Read as Markdown with Mktero`。
-2. Mktero 会打开临时标签页，并显示上传、转换和下载进度。存在有效缓存时会跳过
-   远程转换。
-3. 使用目录、引用和图表预览、来源链接以及 Zotero 笔记面板浏览文档。
-   点击引用跳转到参考文献后，可以使用工具栏中的左箭头按钮，或按
-   `Alt+Left`（macOS 使用 `Command+[`）返回原引用位置。
-4. 使用 Markdown 正文上方的固定工具栏调整字号和字体、切换阅读模式或翻译全文；这些控件
-   省略了可由交互本身表达的可见标题，同时保留无障碍名称，并使用紧凑且一致的间距；
-   常规阅读宽度下，翻译进度会压缩在主工具栏单行内，翻译按钮与阅读模式之间带有分割线。
-   译文可用后，阅读模式 Tab 会直接显示目标语言，不再通过右侧独立标签重复显示。
-   点击该 Tab 会打开语言菜单：完整译文会立即切换，选择不完整或尚未翻译的语言则会继续或开始翻译。
-   简体中文、繁体中文、日文和韩文译文会自动使用对应语言的学术衬线字体回退；选择“阅读译文”
-   时，字体下拉框会切换为当前译文语言的论文阅读字体，“阅读原文”和“双语对照”仍显示原文字体。
-   相关操作可用时，右侧更多
-   菜单包含 `管理校对`、`重新翻译全文`、`重新解析 PDF` 和 `保存快照`。
+1. 在 Zotero 中打开 PDF，点击阅读器工具栏的 Mktero 文件图标；也可以右键 PDF 或文库条目，选择
+   `Read as Markdown with Mktero`。
+2. 在临时 Mktero 标签页中查看上传、转换和下载进度。存在有效缓存时会跳过远程转换。
+3. 使用目录、引用、图表预览、来源链接和 Zotero 笔记面板浏览文档。
+4. 使用阅读器工具栏调整字体、切换阅读模式、翻译、校对识别错误或保存快照。
 
-重新解析会再次上传 PDF，并可能消耗 MinerU 额度。新结果准备完成前，当前 Markdown
-仍可继续阅读。Mktero 标签页仅在当前会话存在，重启 Zotero 后不会自动恢复。
+Mktero 标签页是会话级的，Zotero 重启后不会恢复。关闭标签页或关闭扩展时，进行中的转换和翻译请求会被取消。
 
-### 浏览文库引用图谱
+## 阅读与标注工作流
 
-打开论文的 Markdown 阅读页并点击右下角悬浮的网络图标，或点击 PDF 阅读器工具栏中的
-网络图标。引用图谱会在模态对话框中打开，并自动聚焦当前论文。图谱只包含当前论文，以及
-当前 Zotero 文库中能够匹配到的、当前论文直接引用的论文。暂不显示引用当前论文的论文，
-也不显示文库中的其他论文。
+### 带来源的阅读
 
-引用数据仅来自 Semantic Scholar。Mktero 只发送 DOI 和 arXiv 标识符，不发送 PDF、
-Markdown、笔记、标注、本地路径、Zotero key 或完整条目记录。界面会先显示本地缓存，
-再逐条刷新缺失或过期的数据。搜索、全部/有关联筛选，以及可通过键盘操作的参考文献列表
-都可以聚焦论文；双击节点或点击 `在 Zotero 中打开` 会优先打开 PDF，没有 PDF 时选择对应
-的 Zotero 条目。清空 Mktero 本地缓存也会删除引用记录缓存。
+MinerU 内容映射会把 Markdown 内容块连接到 PDF 的物理页码和区域。来源跳转和附带来源复制只在映射可靠时执行；匹配存在歧义时不会猜测位置。Markdown 在隔离的 shadow root 中渲染，并使用受限的链接和图片策略。
 
 ### 校对识别错误
 
-在普通阅读界面中直接双击段落、标题或 GFM 表格单元格即可编辑。聚焦可编辑内容块后，
-也可以按 `Enter` 或 `F2` 进入编辑。文本和表格使用统一的显式操作栏：只有内容发生变化后
-才会启用“保存”，可以通过“保存”“取消”以及 `Ctrl/Command+Enter` 或 `Escape` 完成一致的
-提交和取消操作。离开表格单元格不会自动保存；保存失败时会保留当前输入，便于重试或取消。
-内容块操作栏还可以直接删除整个段落或标题，无需逐字删除；成功删除后会短暂显示“撤销删除”
-提示。链接、图片、引用和批注等交互元素保留原有的双击行为。
+双击已有段落、标题或 GFM 表格单元格即可编辑，然后显式保存或取消。在 `Manage corrections` 中还可以删除和恢复已有段落或标题。校对数据独立于转换缓存，并绑定当前 PDF 内容和 MinerU 解析配置；不能插入或重排内容块，也不能添加图片或原始 HTML。
 
-在更多菜单中选择 `管理校对`，可以集中查看已修改的内容，并恢复单个已删除的内容块。
-已删除的内容块只会在管理模式中显示紧凑的可恢复占位；普通阅读界面会隐藏校对标记，
-并折叠删除内容留下的间距。更多菜单中仍可以一次恢复全部校对。
+### 从 Markdown 创建标注
 
-校对结果绑定当前 PDF 内容和 MinerU 解析配置，并与转换缓存分开保存，因此缓存清理或
-过期不会删除校对。`重新解析 PDF` 会先确认是否永久删除已有校对；第一版不会将校对
-自动合并到新的解析结果中。编辑范围有意限制在已有段落、标题和 GFM 表格单元格，不能
-插入或移动内容块；可以删除已有段落或标题，但不能新增图片或原始 HTML。
+打开文档时会加载已有的 Zotero 文本高亮和下划线。选中 Markdown 文本后可以立即创建本地标注；只有本地 PDF 文字索引能够可靠定位唯一位置时，Mktero 才会创建对应的 Zotero 标注。重复或歧义文本会保留在本地并可重试，不会被放置到猜测的位置。
 
-如果安装了 Actions & Tags for Zotero，Mktero 会为自己拥有的阅读会话兼容执行
-`openFile` 和 `closeTab` 规则，同时避免重复触发原生阅读器动作。
+### 使用 AI 翻译
 
-### 使用 AI 翻译整篇 Markdown 文章
+AI 翻译始终需要用户主动触发，也不会重写原始 Markdown。Mktero 会把文章拆成受控的 Markdown 批次，保护公式、引用、链接、代码、图片和结构占位符，并最多同时执行 5 个请求。阅读器支持 `Original`、`Translation` 和 `Bilingual` 三种模式；部分结果会按内容块继续补译。
 
-先在 `设置 -> Mktero` 中配置并启用 AI 翻译，再点击 Markdown 标签页工具栏中的
-`翻译全文`。Mktero 会先按 Markdown 一级标题分组经过保护的文档，再将每组拆成最多 8 个
-内容块、约 2000 个估算源文本 Token 的批次，最多同时发送 5 个请求。响应按内容块 ID 匹配并
-按原始顺序合并；缺失或无效的内容块最多单独重试 2 次。若最后一次重试改动了受保护占位符，
-Mktero 会再发起一次兜底请求，仅包含该内容块中带稳定 ID 的普通文本片段；公式、引用、图表
-编号和内部占位符不会进入这次请求。译文片段会在本地与原受保护内容重新组装，并再次通过相同的
-结构、顺序和输出大小校验。参考文献区域保持原样。请求前，
-代码、图片、独立公式、链接定义、原始 HTML、URL、行内代码，以及可交互的论文引用、角标、
-图引用、表引用和对应目标标签会被替换为受保护占位符；只有响应通过结构校验后才会恢复。
-恢复后的数字引用和行内公式即使紧邻中日韩译文，也会继续按引用和数学内容渲染。
-图表说明和引用周围的正文仍会正常翻译。翻译只会在用户明确点击后开始，不会改写原始
-Markdown，也不会进入保存的快照。
-默认使用流式传输，但阅读器
-只在全部请求批次处理完成后更新，不会按每个 token 重绘全文。翻译进行时，工具栏会显示旋转的加载
-图标、目标语言、已完成内容块数量和百分比，并保留“取消翻译”操作；再次点击即可停止当前
-请求。已有完整译文后，取消入口会移入译文语言菜单，当前论文仍可继续阅读。后台重试期间，
-已有的原文、译文和双语视图仍可继续阅读和切换。
+译文会按照源内容、Provider、协议、模型、语言和提示词版本独立缓存。Mktero 通过 Vercel AI SDK Core 支持 OpenAI、Anthropic、Google Gemini、DeepSeek、阿里云百炼、Moonshot/Kimi、MiniMax，以及自定义 OpenAI 兼容或 Open Responses 服务。远程地址必须使用 HTTPS；Ollama、LM Studio 等本地回环服务可以使用 HTTP。
 
-自动重试后仍然失败的内容块会保留原文，并将结果标记为可重试的“部分完成”；已经成功的译文
-仍可阅读。每个未翻译内容块会在正文中明确标记，可从工具栏重试全部未完成翻译，也可在失败
-位置之间跳转；导航控件会显示当前位置和总数，例如 `1/3`。
+### 浏览引用图谱
 
-翻译完成后，可以在工具栏选择 `阅读原文`、`阅读译文` 或 `双语对照`。每次打开文档默认
-显示原文；双语对照使用一个连续阅读文档，每个原文标题、段落、列表、引用或表格后紧跟
-对应译文。译文使用克制的左侧细线、缩进和较弱的标题层级加以区分，目录只保留原文标题；
-工具栏始终显示译文语言，翻译进行时增加进度，部分完成时只显示未翻译数量；全部完成后不再
-重复显示 `N/N`。即使 Zotero 侧栏占用正文宽度，单一阅读面仍能正常阅读。
-在双语对照中，原文内容块继续支持 PDF 标注、来源跳转、带来源复制和新建 Markdown 标注；
-译文内容块不会显示这些仅适用于原文的操作。双语内容块在阅读时保持稳定，不随悬停或聚焦
-高亮，也不提供针对单个内容块的翻译操作；更多菜单中的 `重新翻译全文` 会使用当前 Provider
-和模型设置重新生成当前可见语言的整篇译文。
+引用图谱只包含当前论文，以及能匹配到当前 Zotero 文库条目的直接引用。支持时会并发查询 Semantic Scholar、OpenCitations 和 OpenAlex。匹配只使用唯一且规范化的 DOI 或 arXiv 标识符，不使用标题；Provider 返回的元数据保存在本地。
 
-Mktero 的所有 AI 调用都通过 Vercel AI SDK Core。内置 OpenAI、Anthropic、Google
-Gemini、DeepSeek、阿里云百炼、Moonshot/Kimi 和 MiniMax 适配器，并支持自定义兼容
-服务。协议决定调用 OpenAI Responses、OpenAI Chat Completions、Open Responses、
-Anthropic Messages 或 Google Generative Language；设置页只允许选择与当前模型厂商兼容
-的协议。可用模型及其 ID 仍由厂商决定。远程地址必须使用 HTTPS；Ollama、LM Studio 等
-运行在回环地址上的本地服务可以使用 HTTP，在服务未启用认证时也可以不填 API Key。
+### 保存便携快照
 
-译文内容块保存在对应 PDF 的 Markdown 缓存条目中，并按原文、Provider、协议、模型、
-目标语言和 Prompt 版本区分，每种目标语言保留独立结果。设置中的翻译语言只作为论文首次
-翻译时的默认值；更改设置不会替换、取消或启动已打开 Markdown 标签页中的翻译。只要已有
-完整译文可读，主工具栏就不再显示翻译按钮。译文阅读模式 Tab 的菜单会列出当前论文和模型
-配置支持的全部语言：选择完整语言会直接切换缓存，不会再次请求 AI；选择部分完成或尚未
-翻译的语言会继续或开始该语言的翻译，并且不会修改设置中的默认语言。部分缓存会继续补译
-缺失内容块，不会被误当成完整译文。阅读时会按原始顺序从缓存内容块重建
-完整译文和双语对照文档，因此展示方式更新无需再次请求 AI。
-清除、替换或淘汰该 Markdown 缓存条目时会同时删除其全部译文。列表、引用和 GFM 表格会翻译；
-图片、代码、独立公式、链接定义、原始 HTML 和可交互的学术引用标签保持原样。关闭标签页、
-重新解析、校对 Markdown 或关闭 Mktero 时，进行中的
-翻译请求都会取消。
-
-### 保存便携 Zotero 快照
-
-选择 `保存快照` 后，Mktero 会在 PDF 所属文献条目下创建专用的
-`Mktero Markdown Snapshot` Note。便携 HTML 保存在 Note 中，图片保存为嵌入附件，
-原始 Markdown 和来源映射保存为关联附件，之后由 Zotero 正常同步。
-
-安装 Mktero 的桌面端会优先使用同步的 Markdown 源文件，其他客户端可以直接阅读便携
-HTML Note。用户修改过快照 Note 后，Mktero 会拒绝静默覆盖。没有所属文献条目的独立
-PDF 不能保存快照。
-
-## 核心能力
-
-- 将 OCR 结果、双栏正文、公式、表格、图片、列表和代码重排成连续阅读文档。
-- 在保留 MinerU 原始 Markdown 和校对历史的前提下，修正已有段落、标题和 GFM 表格
-  单元格中的识别错误，并可删除多余的段落或标题。
-- 通过配置的 Vercel AI SDK Provider 使用受控批次并发翻译整篇 Markdown，并支持原文、译文和连续块级双语对照阅读。
-- 使用适合论文阅读的 STIX/Noto 衬线字体回退，并为支持的围栏代码块异步提供 Shiki
-  语法高亮、语言标签和代码复制。
-- 当 MinerU 把标题提取到表格前后，或把表格标题误分配给下一张图片时，自动恢复相邻
-  表格与图片标题的正确归属；合成图的子图文字与正式图注被分开提取时也能正确识别。
-- 保留可靠的 PDF 页码和区域映射，使正文、公式、表格和图片可以返回原始 PDF。
-- 在不离开当前阅读位置的情况下预览引用、作者单位、图片和表格。
-- 在 Markdown 中显示 Zotero PDF 高亮和下划线，并支持新建、改色、评论和删除标注。
-- 来源可靠时，复制内容可附带论文标题、PDF 物理页码和 Zotero 回链。
-- 使用内容寻址的本地缓存，并可恢复最近上传的 MinerU 任务，避免重复上传同一 PDF。
-- 只展示当前 Zotero 文库内部的有向引用关系，并以缓存优先方式刷新 Semantic Scholar 数据。
-- 英文和简体中文界面自动跟随 Zotero 显示语言，其他语言回退为英文。
+`Save snapshot` 会在 PDF 所属条目下创建专用的 `Mktero Markdown Snapshot` Note。Note 保存便携 HTML，图片作为内嵌附件，原始 Markdown 和来源映射作为关联附件。用户修改过快照 Note 后，Mktero 不会静默覆盖。没有父级文库条目的独立 PDF 无法保存快照。
 
 ## 工作原理
 
@@ -217,112 +125,48 @@ MinerU 转换 ----------> Markdown + 图片 + 内容映射
 本地内容缓存                    安全规范化与渲染
                                        |
                                        v
-                            Zotero 中阅读优先的 Mktero 标签页
+                            Zotero 中的 Mktero 阅读标签页
 ```
 
-Mktero 将 PDF、转换结果、压缩包、图片路径、API 响应和首选项都视为不可信输入。
-Markdown 会经过规范化，并在隔离的 shadow root 中渲染，不会作为任意 HTML 插入 Zotero
-chrome 文档。
+PDF、MinerU 结果、压缩包、图片路径、API 响应和首选项都会被视为不可信输入。压缩包和 Markdown 会检查资源预算，归档路径会被规范化，远程 Markdown 图片不会加载，原始 HTML 会在渲染前转义或清理。
 
-## 标注与来源链接
+## 数据与隐私
 
-每次打开文档时，Mktero 都会重新读取已有的 Zotero 文本高亮和下划线。在普通
-Markdown 正文中划词，可以立即创建本地高亮或笔记；Mktero 随后使用本地 PDF.js
-文字索引，仅在能够可靠定位原文时创建对应的 Zotero 标注。失败或存在歧义的匹配会保留
-在本地并允许重试，Mktero 不会猜测 PDF 位置。当选中文本出现多次时，Mktero 会比较选区
-前后最多各 80 个可见字符来区分候选位置，而最终 PDF 高亮仍然只覆盖原选区；如果前后文
-也无法确定唯一候选，匹配会继续保持歧义。上下文消歧依赖本地 PDF.js 文字索引；如果该索引
-不可用，Zotero 阅读器兜底会让重复选区继续保持歧义，而不会扩大 PDF 高亮范围。匹配过程
-可兼容引用上标、统计指数、包括紧跟左括号写法在内的 LaTeX 关系运算符、错误解码的温度
-度数符号、Markdown 转义百分号和 PDF 跨行断词。同一选区中的词内连字符与行尾断词
-连字符可分别判断；同一视觉行内错位的连字或数字前缀符号也会被规范化。
-错误编码的正负号只会在长篇且唯一匹配的文本中进行兼容处理。
-
-将已有 Zotero PDF 标注加载到 Markdown 时，Mktero 会根据标注的页码和排序索引定位
-它在 PDF 中的准确出现位置，再取其前后最多各 80 个字符，与经过可靠页码过滤后剩余的
-Markdown 候选位置上下文进行比较。Markdown 中的覆盖范围仍只包含原始标注文本；如果
-PDF 索引、来源偏移或上下文无法确定唯一候选，标注会继续保持歧义，而不会被放到猜测的位置。
-
-可靠的 MinerU 内容映射也用于来源跳转和附带来源复制。页码提示会将标注匹配限制在正确的
-PDF 物理页；区域坐标只用于来源跳转，不会被当作猜测的标注矩形。
-
-## 缓存与隐私
-
-| 数据 | 保存或发送位置 | Zotero 同步 |
+| 数据 | 发送到或存储在 | Zotero 同步 |
 | --- | --- | --- |
-| 缓存未命中时的完整 PDF | 上传到 MinerU | Mktero 不同步 |
-| API Token | 当前 Zotero 配置文件，未加密 | 否 |
-| AI API Key | 当前 Zotero 配置文件，未加密 | 否 |
-| Semantic Scholar API Key | 当前 Zotero 配置文件，未加密 | 否 |
-| 引用图谱使用的 DOI 和 arXiv 标识符 | Semantic Scholar | Mktero 不同步 |
-| 用户选择全文翻译后拆分的受保护 Markdown 批次，以及仅在占位符完整性连续失败后使用的普通文本片段 | 配置的 AI Provider | Mktero 不同步 |
-| 缓存的 Markdown、图片、来源映射和 PDF 文字索引 | 当前 Zotero 配置文件，未加密 | 否 |
-| 缓存的 AI 译文 | 当前 Zotero 配置文件，未加密 | 否 |
-| 缓存的 Semantic Scholar 引用元数据 | 当前 Zotero 配置文件，未加密 | 否 |
-| 待完成 MinerU 任务的 ID 和时间戳 | 当前 Zotero 配置文件，未加密 | 否 |
-| 待同步的 Markdown 标注记录（包括用于匹配的有界前后文） | 当前 Zotero 配置文件，同步前未加密保存 | 否 |
-| 校对后的 Markdown 内容块及其基础图片和来源映射 | 当前 Zotero 配置文件，未加密 | 否 |
-| 已同步的 PDF 标注 | 本地 Zotero 文库 | 取决于 Zotero 设置 |
-| 保存的快照 Note、HTML、Markdown、来源映射和图片 | Zotero 条目和附件，未加密 | 取决于 Zotero 设置 |
+| 缓存未命中时的完整 PDF | MinerU | Mktero 不同步 |
+| MinerU API Token 和 AI/Provider 凭据 | 当前 Zotero 配置文件，未加密 | 否 |
+| 缓存的 Markdown、图片、来源映射、PDF 索引、校对和译文 | 当前 Zotero 配置文件，未加密 | 否 |
+| 当前论文的 DOI/arXiv 标识符及 Provider 所需的候选 DOI | Semantic Scholar、OpenCitations 或 OpenAlex | Mktero 不同步 |
+| 受保护的 Markdown 翻译批次 | 你配置的 AI Provider | Mktero 不同步 |
+| Zotero PDF 标注 | 本地 Zotero 文库 | 取决于 Zotero 设置 |
+| 保存的快照 Note 和附件 | Zotero 条目和附件 | 取决于 Zotero 设置 |
 
-本地缓存不包含 API Token、Semantic Scholar API Key、AI API Key 或 PDF 标注评论。PDF 标注和本地 PDF.js 索引
-不会发送给 MinerU 或 AI Provider。全文翻译会向配置的 AI Provider 并发发送最多 5 个
-经过保护的 Markdown 批次和翻译指令。若某个内容块的占位符完整性连续校验失败，最后一次请求
-只发送该块的普通文本片段，受保护公式、引用、图表编号和占位符仍保留在本地。“复制并附带来源”只读取本地条目元数据，并将生成的结果
-写入系统剪贴板。引用图谱请求只向 Semantic Scholar 发送规范化后的 DOI 和 arXiv 标识符；
-引用元数据缓存保存在本地、未加密且不会由 Zotero 同步，外部 Semantic Scholar 论文不会成为图谱节点。
+Mktero 不会把 PDF 标注、本地 PDF.js 索引、Zotero 笔记、完整条目记录、本地路径或缓存 Markdown 发送给 MinerU 或引用 Provider。翻译请求包含受保护的 Markdown 和指令；如果占位符校验连续失败，最后一次重试只发送受影响内容块中的普通文本片段。日志不会写入 API Token、预签名地址、PDF 字节或带认证的响应。
 
-校对数据保存在当前 Zotero 配置文件中，并独立于普通转换缓存；清理缓存不会清理校对。
-校对默认只保存在当前设备，除非用户将其保存到 Zotero 快照。包含校对的快照会明确显示
-来源说明和校对数量。
+请同时阅读 MinerU、AI Provider 和引用 Provider 的隐私政策。除非相关数据处理条款符合你的使用场景，否则不要处理机密 PDF。
 
-待完成任务记录只包含 MinerU 任务标识、Mktero data ID 和上传时间，不包含 PDF、
-文件名、本地路径、上传或下载地址、API Token 或带认证的 API 响应。
+## 当前限制
 
-保存的快照不包含原始 PDF、MinerU 结果压缩包、API Token 或 API 响应；其同步方式和
-存储配额由 Zotero 控制。
-
-## 安全边界与当前限制
-
-- Markdown 默认只读。校对模式可以替换已有段落、标题和 GFM 表格单元格的内容，也可
-  删除已有段落或标题；除此之外不能改变文档结构、公式、图片或原始 HTML。标注操作与
-  Markdown 校对相互独立。
-- AI 翻译是可选的本地缓存阅读层，不会自动开始，不修改原始 Markdown，不通过 Zotero
-  同步，也不会把译文写入快照。所有调用通过 Vercel AI SDK Core，并按所选模型厂商和协议
-  路由；Mktero 会优先请求关闭推理以提高翻译速度。如果所选模型或 Provider 明确拒绝
-  关闭推理，Mktero 会使用该 Provider 的默认行为重试一次，且暂不开放推理强度设置。
-- 仅支持本地 PDF 附件；缺失或尚未下载的文件无法转换。
-- 文本标注依赖可提取的 PDF 文字层。扫描版 PDF 可能可以通过 OCR 转换，但仍无法生成
-  精确的 Zotero 高亮矩形。
-- 当前只显示文本高亮和下划线，不显示独立便签、图片或区域标注以及手写标注。
-- 来源跳转依赖稳定版 MinerU `*_content_list.json`。旧缓存仍可阅读，但可能没有来源
-  链接。
-- 当前只支持从 Markdown 跳转到 PDF；尚不支持反向跳转和原译文同步滚动。
-- Markdown 图片只能解析当前结果压缩包中的 GIF、JPEG、PNG 和 WebP，不加载远程图片。
-- 链接协议限定为 `http`、`https`、`zotero` 和当前文档片段。
-- 原始 HTML 默认转义；清理后的 MinerU 表格只允许有限的标签和属性。
-- 压缩包、Markdown、图片、来源映射、PDF 索引和 KaTeX 渲染均有本地资源上限，超限时
-  会安全停止处理。
+- 仅支持本地 PDF 附件。扫描版 PDF 可以通过 OCR 转换，但没有文字层时无法生成精确的 Zotero 高亮。
+- 来源跳转依赖稳定的 MinerU `*_content_list.json`；旧缓存可能仍可阅读，但没有来源链接。
+- 当前只支持从 Markdown 跳转到 PDF，不支持反向跳转。
+- 目前显示文本高亮和下划线，不显示独立便签、图片/区域标注或手写标注。
+- Markdown 图片仅限当前结果压缩包中的 GIF、JPEG、PNG 和 WebP；远程图片会被阻止。
+- 链接协议仅允许 `http`、`https`、`zotero` 和文档片段。
+- 校对模式只能编辑或删除已有内容块，不能改变文档结构、公式、图片或原始 HTML。
+- AI 翻译是可选的缓存阅读层，不修改源 Markdown，也不会写入快照。
+- 压缩包、Markdown、图片、来源映射、PDF 索引和 KaTeX 渲染都有本地资源上限，超限时会安全停止处理。
 
 ## 转换排障
 
-在 Zotero 中打开 `帮助 -> 调试输出日志`，启用日志后重新执行转换，并筛选 `Mktero:`。
-常见阶段包括：
+在 Zotero 中打开 `帮助 -> 调试输出日志`，启用日志后重现问题，并筛选 `Mktero:`。请确认 PDF 已下载到本机、MinerU Token 有效且当前网络可以访问 MinerU。日志不会包含 API Token、预签名上传地址、MinerU batch ID 或 PDF 内容。
 
-- `requesting a MinerU upload URL`
-- `uploading PDF to MinerU`
-- `PDF upload completed; MinerU is parsing`
-- `MinerU parsing finished; downloading the result`
-- `completed from local cache; MinerU upload skipped`
-- `completed from a resumed MinerU task`
-
-日志不会记录 API Token、预签名上传地址、MinerU batch ID 或 PDF 内容。若仍然失败，
-请确认附件已下载到本机、Token 有效，并且当前网络可以访问 MinerU。
+确认问题可复现后，请提交 [GitHub Issue](https://github.com/tenglvjun/mktero/issues)，并附上 Zotero 与 Mktero 版本、操作系统、PDF 类型、复现步骤、预期行为和实际行为。请勿附带 API Token、私密 PDF、带认证链接或本地文件路径。
 
 ## 开发
 
-使用 [`.node-version`](./.node-version) 指定的 Node.js `24.15.0`。Node.js 25 不在依赖
-支持范围内。
+使用 [`.node-version`](./.node-version) 指定的 Node.js 版本，目前为 `24.15.0`。Node.js 25 不在支持范围内。
 
 ```bash
 npm ci
@@ -331,28 +175,14 @@ npm test
 npm run build
 ```
 
-构建会生成未压缩扩展、可复现的 `build/mktero-<version>.xpi`、SHA-256 校验文件以及
-`build/updates.json`。生成的 `build/` 和 `node_modules/` 目录已被忽略，不应提交。
+迭代时可以使用 `node --test test/<name>.test.js` 运行单个测试。构建会在 `build/` 下生成可复现的 XPI、SHA-256 校验文件和 `build/updates.json`；`build/` 与 `node_modules/` 都是生成目录并已被忽略。
 
-创建 `v<version>` 标签前，必须保持 `manifest.json`、`package.json` 和
-`package-lock.json` 中的版本一致。Release 工作流会在发布前校验标签与
-`manifest.json` 的版本。普通推送和 Pull Request 只执行测试、构建与 CodeQL，
-不会发布新版本。
+发布前请保持 `manifest.json`、`package.json` 和 `package-lock.json` 的版本一致。仓库架构、安全约束和贡献检查清单见 [AGENTS.md](./AGENTS.md)。
 
-仓库架构、编码规则、安全约束和跨文件修改清单见 [AGENTS.md](./AGENTS.md)。
+## 贡献
 
-## 反馈与贡献
-
-- 阅读工作流、功能想法和 Beta 反馈请前往
-  [GitHub Discussions](https://github.com/tenglvjun/mktero/discussions)。
-- 已确认且可以复现的问题请提交到
-  [GitHub Issues](https://github.com/tenglvjun/mktero/issues)。
-
-反馈时请提供 Zotero 与 Mktero 版本、操作系统、PDF 类型、复现步骤、预期行为和实际
-行为。请勿提交 API Token、私密 PDF、带认证信息的链接、本地文件路径或其他敏感信息。
-
-欢迎提交 Pull Request。修改运行时行为时，请执行上面的完整验证命令并遵循
-[AGENTS.md](./AGENTS.md)。
+欢迎提交 Pull Request。功能想法、阅读工作流和 Beta 反馈请前往
+[GitHub Discussions](https://github.com/tenglvjun/mktero/discussions)；确认且可复现的问题请提交到 [GitHub Issues](https://github.com/tenglvjun/mktero/issues)。修改运行时行为时，请运行上面的完整验证命令并为受影响的行为补充测试。请勿在 Issue、Pull Request 或日志中提交凭据、私密 PDF 或其他敏感信息。
 
 ## License
 


### PR DESCRIPTION
## Summary

- Reorganize the English and Simplified Chinese README files for an open-source project landing page.
- Clarify installation, configuration, reading workflows, AI translation, citation graph, snapshots, privacy, limitations, troubleshooting, development, and contribution guidance.
- Keep the English and Chinese documentation aligned with the current Zotero 7-9 compatibility and runtime behavior.

## Validation

- `git diff --check`
- Local README link check
- Full test suite not run because this PR only changes documentation.