### PR TITLE
test: allow version metadata updates

### DIFF
--- a/test/manifest.test.js
+++ b/test/manifest.test.js
@@ -35,8 +35,11 @@ test('declares the scalable Mktero logo for extension surfaces', () => {
     });
 });
 
-test('keeps the installable package version metadata consistent', () => {
-    assert.equal(manifest.version, '0.3.3');
+test('keeps the installable package version metadata valid and consistent', () => {
+    assert.match(
+        manifest.version,
+        /^(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)$/
+    );
     assert.equal(packageMetadata.version, manifest.version);
     assert.equal(packageLock.version, manifest.version);
     assert.equal(packageLock.packages[''].version, manifest.version);


### PR DESCRIPTION
## Summary

- replace the hard-coded `0.3.3` manifest assertion with strict numeric `X.Y.Z` validation
- preserve consistency checks across `manifest.json`, `package.json`, and both root `package-lock.json` version fields
- unblock repeatable version bumps without weakening package metadata validation

## Testing

- `node --test test/manifest.test.js` (4 passed)
- `npm run check`
- `npm test` (1445 passed)
- `npm run build`