### PR TITLE
chore: release 0.3.4

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "dependencies": {
         "@ai-sdk/alibaba": "^2.0.33",
         "@ai-sdk/anthropic": "^4.0.40",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",


### PR DESCRIPTION
## Summary

- update Mktero version metadata from `0.3.3` to `0.3.4`
- keep `manifest.json`, `package.json`, and both root `package-lock.json` version fields synchronized

## Verification

- `npm ci`
- `npm run check`
- `npm test` (1445 passed)
- `npm run build`
- verified `build/mktero-0.3.4.xpi`, checksum, and `updates.json`

## Prerequisite

- #86 removes the hard-coded previous release version from package metadata tests