### PR TITLE
Stream selection translations in popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,14 +158,17 @@ For a focused lookup, select text in `Original` or on the source side of
 `Bilingual` reading. The selection popup places its manual translation action
 at the end of the action row; loading, results, and errors expand below it only
 when needed in a compact panel. A successful result can be translated again or
-copied as plain text. The `Automatically translate Markdown selections` setting
-is off by default; when enabled, a stable selection starts one bounded request
-automatically after a short delay. The translated side of `Bilingual`,
-`Translation` reading, and saved HTML snapshots do not offer selection
-translation. Selection results stay in the popup, do not modify Markdown or
-notes, and are not added to the full-document translation cache. Each selection
-request sends the selected text and a bounded amount of nearby source context
-to the configured AI provider and may incur provider usage costs.
+copied as plain text. With a streaming provider, incoming translation text
+appears progressively while cancellation remains available; non-streaming
+providers display the result after completion. The `Automatically translate
+Markdown selections` setting is off by default; when enabled, a stable
+selection starts one bounded request automatically after a short delay. The
+translated side of `Bilingual`, `Translation` reading, and saved HTML snapshots
+do not offer selection translation. Selection results stay in the popup, do not
+modify Markdown or notes, and are not added to the full-document translation
+cache. Each selection request sends the selected text and a bounded amount of
+nearby source context to the configured AI provider and may incur provider
+usage costs.
 
 Mktero includes adapters for OpenAI, Anthropic, Google Gemini, DeepSeek,
 Alibaba Cloud Model Studio, Moonshot/Kimi, MiniMax, and custom OpenAI-compatible

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -105,7 +105,7 @@ MinerU 内容映射会把 Markdown 内容块连接到 PDF 的物理页码和区�
 
 AI 全文翻译需要用户主动触发，也不会重写原始 Markdown。Mktero 会把文章拆成受控的 Markdown 批次，保护公式、引用、链接、代码、图片和结构占位符，并最多同时执行 5 个请求。阅读器支持 `Original`、`Translation` 和 `Bilingual` 三种模式；部分结果会按内容块继续补译。
 
-如需查询术语或复杂句子，可以在 `Original` 或 `Bilingual` 的原文侧选中文本，使用选区弹窗工具栏末尾的翻译操作；加载、结果和错误只在需要时于下方紧凑展开。翻译成功后可以重新翻译或复制纯文本译文。`自动翻译 Markdown 选区`默认关闭；开启后，选区稳定一小段时间会自动发起一次受控请求。`Translation`、`Bilingual` 的译文侧和已保存的 HTML 快照不提供划词翻译。选区译文只显示在弹窗中，不会修改 Markdown 或笔记，也不会写入全文翻译缓存。每次选区请求只会把选中文本和附近受限长度的原文上下文发送给配置的 AI Provider，可能产生 Provider 费用。
+如需查询术语或复杂句子，可以在 `Original` 或 `Bilingual` 的原文侧选中文本，使用选区弹窗工具栏末尾的翻译操作；加载、结果和错误只在需要时于下方紧凑展开。使用流式 Provider 时，译文会在请求期间逐步显示，并且仍可取消；非流式 Provider 会在翻译完成后一次性显示结果。翻译成功后可以重新翻译或复制纯文本译文。`自动翻译 Markdown 选区`默认关闭；开启后，选区稳定一小段时间会自动发起一次受控请求。`Translation`、`Bilingual` 的译文侧和已保存的 HTML 快照不提供划词翻译。选区译文只显示在弹窗中，不会修改 Markdown 或笔记，也不会写入全文翻译缓存。每次选区请求只会把选中文本和附近受限长度的原文上下文发送给配置的 AI Provider，可能产生 Provider 费用。
 
 译文会按照源内容、Provider、协议、模型、语言和提示词版本独立缓存。Mktero 通过 Vercel AI SDK Core 支持 OpenAI、Anthropic、Google Gemini、DeepSeek、阿里云百炼、Moonshot/Kimi、MiniMax，以及自定义 OpenAI 兼容或 Open Responses 服务。远程地址必须使用 HTTPS；Ollama、LM Studio 等本地回环服务可以使用 HTTP。
 

--- a/src/ai/markdown-translation-service.js
+++ b/src/ai/markdown-translation-service.js
@@ -332,6 +332,7 @@ export class MarkdownTranslationService {
         context = '',
         signal,
         targetLanguage,
+        onTextDelta,
     }) {
         const configuredSettings = this.getSettings();
         const selectedLanguage = targetLanguage === undefined
@@ -379,7 +380,10 @@ export class MarkdownTranslationService {
         };
         const result = settings.streaming !== false
             && typeof this.aiGateway.streamText === 'function'
-            ? await this.aiGateway.streamText(request)
+            ? await this.aiGateway.streamText({
+                ...request,
+                onTextDelta,
+            })
             : await this.aiGateway.generateText(request);
         throwIfDocumentAborted(signal);
         if (selectionFinishReason(result?.finishReason) === 'length') {

--- a/src/bootstrap.js
+++ b/src/bootstrap.js
@@ -558,8 +558,8 @@ async function openItemAsMarkdown(itemID, {
         onRestoreAllCorrections: () => restoreAllCorrections(itemID),
         onTranslateDocument: options => translateDocument(itemID, options),
         onCancelDocumentTranslation: () => cancelDocumentTranslation(itemID),
-        onTranslateSelection: ({ text, context } = {}) => (
-            translateSelection(itemID, { text, context })
+        onTranslateSelection: ({ text, context, onTextDelta } = {}) => (
+            translateSelection(itemID, { text, context, onTextDelta })
         ),
         onCancelSelectionTranslation: () => cancelSelectionTranslation(itemID),
         shouldAutoTranslateSelection: () => isAutoSelectionTranslationEnabled(),
@@ -799,8 +799,8 @@ function createSavedMarkdownActions(noteID, sourceItem) {
             copySourcedMarkdown(itemID, target)
         )),
         onCopyCode: code => copyCode(code),
-        onTranslateSelection: ({ text, context } = {}) => (
-            translateSelection(noteID, { text, context })
+        onTranslateSelection: ({ text, context, onTextDelta } = {}) => (
+            translateSelection(noteID, { text, context, onTextDelta })
         ),
         onCancelSelectionTranslation: () => cancelSelectionTranslation(noteID),
         shouldAutoTranslateSelection: () => isAutoSelectionTranslationEnabled(),
@@ -1114,6 +1114,7 @@ async function translateSelection(documentID, {
     text,
     context = '',
     targetLanguage: requestedTargetLanguage,
+    onTextDelta,
 } = {}) {
     const presentation = runtime.presenter?.get(documentID);
     const service = runtime.translationService;
@@ -1150,6 +1151,7 @@ async function translateSelection(documentID, {
             context,
             signal,
             targetLanguage,
+            onTextDelta,
         })
     );
 }

--- a/src/editor/annotation-popup.js
+++ b/src/editor/annotation-popup.js
@@ -178,9 +178,14 @@ export function createAnnotationPopup(parent, {
                             : undefined,
                         translateSelection:
                             typeof translateSelection === 'function'
-                                ? text => translateSelection(
+                                ? (
                                     text,
-                                    selectionContext
+                                    translationContext,
+                                    options,
+                                ) => translateSelection(
+                                    text,
+                                    translationContext,
+                                    options,
                                 )
                             : undefined,
                         cancelSelectionTranslation:
@@ -571,12 +576,22 @@ function createMarkdownSelectionActions(
         clearAutoTranslateTimer();
         const requestID = ++translationRequestID;
         translatedText = '';
+        translationResult.textContent = '';
         setExistingControlsBusy(true);
         setTranslationStatus('loading');
         try {
             const result = await translateSelection(
                 annotation.text,
-                selectionContext
+                selectionContext,
+                {
+                    onTextDelta(_chunk, accumulated) {
+                        if (requestID !== translationRequestID) return;
+                        translatedText = String(accumulated ?? '');
+                        translationResult.textContent = translatedText;
+                        translationResult.hidden = !translatedText;
+                        reposition?.();
+                    },
+                },
             );
             if (requestID !== translationRequestID) return;
             const text = typeof result === 'string' ? result : result?.text;
@@ -587,11 +602,15 @@ function createMarkdownSelectionActions(
             }
             translatedText = text;
             translationResult.textContent = text;
+            translationRequestID += 1;
             setExistingControlsBusy(false);
             setTranslationStatus('success');
         }
         catch (cause) {
             if (requestID !== translationRequestID) return;
+            translationRequestID += 1;
+            translatedText = '';
+            translationResult.textContent = '';
             setExistingControlsBusy(false);
             translationError.textContent = annotationErrorMessage(
                 cause,
@@ -607,6 +626,8 @@ function createMarkdownSelectionActions(
         clearAutoTranslateTimer();
         translationRequestID += 1;
         cancelSelectionTranslation?.();
+        translatedText = '';
+        translationResult.textContent = '';
         setExistingControlsBusy(false);
         setTranslationStatus('idle');
     };

--- a/src/editor/inline-markdown-editor.js
+++ b/src/editor/inline-markdown-editor.js
@@ -153,9 +153,10 @@ export function createInlineMarkdownEditor({
         deleteAnnotation,
         copySourcedMarkdown,
         translateSelection: typeof translateSelection === 'function'
-            ? (text, selectionContext) => translateSelection(
+            ? (text, selectionContext, options) => translateSelection(
                 text,
-                selectionContext
+                selectionContext,
+                options,
             )
             : undefined,
         cancelSelectionTranslation,

--- a/src/ui/markdown-window.js
+++ b/src/ui/markdown-window.js
@@ -316,9 +316,14 @@ class MarkdownTabView {
                 ? code => this.copyCode(code)
                 : null,
             translateSelection: typeof model?.onTranslateSelection === 'function'
-                ? (text, selectionContext) => this.model.onTranslateSelection({
+                ? (
+                    text,
+                    selectionContext,
+                    { onTextDelta } = {},
+                ) => this.model.onTranslateSelection({
                     text,
                     context: selectionContext?.translationContext || '',
+                    onTextDelta,
                 })
                 : null,
             cancelSelectionTranslation:

--- a/test/inline-markdown-editor.test.js
+++ b/test/inline-markdown-editor.test.js
@@ -5681,13 +5681,22 @@ test('places translation last, expands results below, and translates again', asy
     const anchor = document.createElement('span');
     parent.appendChild(anchor);
     let resolveTranslation;
+    let emitTranslationDelta;
     let translationCalls = 0;
     let copiedText;
     const popup = createAnnotationPopup(parent, {
-        translateSelection: (text, selectionContext) => {
+        translateSelection: (text, selectionContext, { onTextDelta } = {}) => {
             translationCalls += 1;
+            emitTranslationDelta = onTextDelta;
             assert.equal(text, 'Selected **text**');
             assert.deepEqual(selectionContext, { side: 'source' });
+            if (translationCalls === 1) {
+                onTextDelta('<b>Trans', '<b>Trans');
+                onTextDelta('lated</b>', '<b>Translated</b>');
+            }
+            else {
+                onTextDelta('Re', 'Re');
+            }
             return new Promise(resolve => {
                 resolveTranslation = resolve;
             });
@@ -5746,6 +5755,10 @@ test('places translation last, expands results below, and translates again', asy
     assert.equal(translateButton.hidden, true);
     assert.equal(translationPanel.hidden, false);
     assert.ok(actions.querySelector('[data-action="cancel-selection-translation"]'));
+    const result = actions.querySelector('.mktero-selection-translation-result');
+    assert.equal(result.hidden, false);
+    assert.equal(result.textContent, '<b>Translated</b>');
+    assert.equal(result.querySelector('b'), null);
 
     resolveTranslation({ text: '<b>Translated</b>' });
     await Promise.resolve();
@@ -5753,9 +5766,10 @@ test('places translation last, expands results below, and translates again', asy
 
     assert.equal(actions.dataset.translationStatus, 'success');
     assert.equal(translateButton.hidden, true);
-    const result = actions.querySelector('.mktero-selection-translation-result');
     assert.equal(result.textContent, '<b>Translated</b>');
     assert.equal(result.querySelector('b'), null);
+    emitTranslationDelta(' late', 'Late streamed text');
+    assert.equal(result.textContent, '<b>Translated</b>');
     assert.deepEqual(
         [...translationPanel.querySelectorAll(
             '.mktero-selection-translation-actions button'
@@ -5783,7 +5797,8 @@ test('places translation last, expands results below, and translates again', asy
     retranslateButton.click();
     assert.equal(translationCalls, 2);
     assert.equal(actions.dataset.translationStatus, 'loading');
-    assert.equal(result.hidden, true);
+    assert.equal(result.hidden, false);
+    assert.equal(result.textContent, 'Re');
     assert.ok(actions.querySelector(
         '[data-action="cancel-selection-translation"]'
     ));
@@ -5868,8 +5883,11 @@ test('shows a localized error when a selection exceeds the translation limit', a
     const parent = document.querySelector('#popup-parent');
     const anchor = document.createElement('span');
     parent.appendChild(anchor);
+    let emitTranslationDelta;
     const popup = createAnnotationPopup(parent, {
-        translateSelection: async () => {
+        translateSelection: async (_text, _context, { onTextDelta } = {}) => {
+            emitTranslationDelta = onTextDelta;
+            onTextDelta('Partial', 'Partial translation');
             const error = new Error('too large');
             error.code = 'AI_INPUT_TOO_LARGE';
             throw error;
@@ -5887,10 +5905,60 @@ test('shows a localized error when a selection exceeds the translation limit', a
 
     const actions = parent.querySelector('.mktero-markdown-selection-actions');
     assert.equal(actions.dataset.translationStatus, 'error');
+    const result = actions.querySelector('.mktero-selection-translation-result');
+    assert.equal(result.hidden, true);
+    assert.equal(result.textContent, '');
+    emitTranslationDelta(' late', 'Late partial translation');
+    assert.equal(result.hidden, true);
+    assert.equal(result.textContent, '');
     assert.equal(
         actions.querySelector('.mktero-selection-translation-error').textContent,
         'Select a shorter passage and try again.'
     );
+
+    popup.destroy();
+    dom.window.close();
+});
+
+test('clears streamed selection text on cancellation and ignores late deltas', () => {
+    const dom = new JSDOM('<!doctype html><div id="popup-parent"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const parent = document.querySelector('#popup-parent');
+    const anchor = document.createElement('span');
+    parent.appendChild(anchor);
+    let onTextDelta;
+    let cancellations = 0;
+    const popup = createAnnotationPopup(parent, {
+        translateSelection: (_text, _context, options) => {
+            onTextDelta = options.onTextDelta;
+            return new Promise(() => {});
+        },
+        cancelSelectionTranslation: () => {
+            cancellations += 1;
+        },
+    });
+
+    popup.openSelection({
+        anchor,
+        selection: { text: 'Selected text' },
+    });
+    const actions = parent.querySelector('.mktero-markdown-selection-actions');
+    actions.querySelector('[data-action="translate-selection"]').click();
+    onTextDelta('Partial', 'Partial translation');
+
+    const result = actions.querySelector('.mktero-selection-translation-result');
+    assert.equal(result.hidden, false);
+    assert.equal(result.textContent, 'Partial translation');
+
+    actions.querySelector('[data-action="cancel-selection-translation"]').click();
+    assert.equal(cancellations, 1);
+    assert.equal(actions.dataset.translationStatus, 'idle');
+    assert.equal(result.textContent, '');
+    onTextDelta(' late', 'Partial translation late');
+    assert.equal(result.hidden, true);
+    assert.equal(result.textContent, '');
 
     popup.destroy();
     dom.window.close();
@@ -5906,9 +5974,13 @@ test('does not let a late selection translation replace a newer popup state', as
     const secondAnchor = document.createElement('span');
     parent.append(firstAnchor, secondAnchor);
     const resolves = [];
+    const deltas = [];
     let cancellations = 0;
     const popup = createAnnotationPopup(parent, {
-        translateSelection: () => new Promise(resolve => resolves.push(resolve)),
+        translateSelection: (_text, _context, { onTextDelta } = {}) => {
+            deltas.push(onTextDelta);
+            return new Promise(resolve => resolves.push(resolve));
+        },
         cancelSelectionTranslation: () => {
             cancellations += 1;
         },
@@ -5927,11 +5999,21 @@ test('does not let a late selection translation replace a newer popup state', as
     assert.equal(cancellations, 1);
     assert.equal(resolves.length, 2);
 
+    deltas[0]('Stale', 'Stale first stream');
+    const currentResult = parent.querySelector(
+        '.mktero-selection-translation-result'
+    );
+    assert.equal(currentResult.hidden, true);
+    assert.equal(currentResult.textContent, '');
+    deltas[1]('Current', 'Current second stream');
+    assert.equal(currentResult.hidden, false);
+    assert.equal(currentResult.textContent, 'Current second stream');
+
     resolves[0]({ text: 'Stale first result' });
     await Promise.resolve();
     assert.equal(
-        parent.querySelector('.mktero-selection-translation-result').hidden,
-        true
+        currentResult.textContent,
+        'Current second stream'
     );
     assert.equal(
         parent.querySelector('.mktero-markdown-selection-actions')
@@ -6043,8 +6125,14 @@ test('passes selection translation callbacks and bounded raw-source context', as
     const editor = createInlineMarkdownEditor({
         parent: document.querySelector('#editor'),
         initialMarkdown: '',
-        translateSelection: async (text, selectionContext) => {
+        translateSelection: async (
+            text,
+            selectionContext,
+            { onTextDelta } = {},
+        ) => {
             calls.push({ text, selectionContext });
+            onTextDelta('Streamed ', 'Streamed ');
+            onTextDelta('selection', 'Streamed selection');
             return { text: 'Translated selection' };
         },
         cancelSelectionTranslation: () => {

--- a/test/markdown-editor-styles.test.js
+++ b/test/markdown-editor-styles.test.js
@@ -24,6 +24,13 @@ function lastRuleBody(selector) {
     return ruleBodies(selector).at(-1);
 }
 
+function pixelDeclaration(body, property) {
+    const escapedProperty = property.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const match = body.match(new RegExp(`${escapedProperty}:\\s*(\\d+)px`));
+    assert.ok(match, `Missing pixel declaration: ${property}`);
+    return Number(match[1]);
+}
+
 test('uses balanced typography for long-form Markdown', () => {
     const host = ruleBody(':host');
 
@@ -162,6 +169,20 @@ test('keeps block correction actions compact and above the editor', () => {
     assert.match(deleted, /display:\s*flex/);
     assert.match(deleted, /border:\s*1px dashed/);
     assert.match(deleted, /min-height:\s*36px/);
+});
+
+test('keeps block correction actions clear of the citation graph button', () => {
+    const graphButton = ruleBody('.markdown-citation-graph-button');
+    const toolbar = ruleBody('.mktero-correction-editor-toolbar');
+    const graphInset = pixelDeclaration(graphButton, 'inset-inline-end');
+    const graphWidth = pixelDeclaration(graphButton, 'width');
+    const toolbarInset = pixelDeclaration(toolbar, 'inset-inline-end');
+
+    assert.ok(
+        toolbarInset >= graphInset + graphWidth + 8,
+        'Correction actions must leave 8px beside the citation graph button'
+    );
+    assert.match(toolbar, /max-width:\s*calc\(100% - 84px\)/);
 });
 
 test('keeps the deleted-correction undo prompt usable with long copy', () => {

--- a/test/markdown-translation-service.test.js
+++ b/test/markdown-translation-service.test.js
@@ -2173,11 +2173,14 @@ test('translates one bounded selection without using document cache', async () =
 test('uses the configured streaming gateway for selection translation', async () => {
     let streamCalls = 0;
     let generateCalls = 0;
+    const deltas = [];
     const service = new MarkdownTranslationService({
         aiGateway: {
             async streamText(request) {
                 streamCalls++;
                 assert.match(request.messages[0].content, /French/);
+                request.onTextDelta('Texte', 'Texte');
+                request.onTextDelta(' traduit', 'Texte traduit');
                 return { text: 'Texte traduit', model: 'stream-model' };
             },
             async generateText() {
@@ -2192,10 +2195,19 @@ test('uses the configured streaming gateway for selection translation', async ()
         }),
     });
 
-    const result = await service.translateSelection({ text: 'A sentence.' });
+    const result = await service.translateSelection({
+        text: 'A sentence.',
+        onTextDelta: (chunk, accumulated) => {
+            deltas.push([chunk, accumulated]);
+        },
+    });
 
     assert.equal(result.text, 'Texte traduit');
     assert.equal(result.targetLanguage, 'fr-FR');
+    assert.deepEqual(deltas, [
+        ['Texte', 'Texte'],
+        [' traduit', 'Texte traduit'],
+    ]);
     assert.equal(streamCalls, 1);
     assert.equal(generateCalls, 0);
 });
@@ -2207,6 +2219,7 @@ test('falls back to generateText when streaming is unavailable', async () => {
             async generateText(request) {
                 generateCalls++;
                 assert.equal(request.settings.targetLanguage, 'ja-JP');
+                assert.equal('onTextDelta' in request, false);
                 return { text: '翻訳文' };
             },
         },

--- a/test/markdown-window.test.js
+++ b/test/markdown-window.test.js
@@ -1581,12 +1581,14 @@ test('forwards selection translation callbacks through the current reader model'
         shouldAutoTranslateSelection: () => true,
         onCopySelectionTranslation: text => calls.push(['copy-second', text]),
     };
+    const onTextDelta = () => {};
 
     try {
         view.render(secondModel);
         await editorOptions.translateSelection(
             'Selected text.',
-            { translationContext: 'Before selected text. Selected text. After.' }
+            { translationContext: 'Before selected text. Selected text. After.' },
+            { onTextDelta },
         );
         editorOptions.cancelSelectionTranslation();
         assert.equal(editorOptions.shouldAutoTranslateSelection(), true);
@@ -1596,6 +1598,7 @@ test('forwards selection translation callbacks through the current reader model'
             ['second', {
                 text: 'Selected text.',
                 context: 'Before selected text. Selected text. After.',
+                onTextDelta,
             }],
             ['cancel-second'],
             ['copy-second', '已翻译文本'],

--- a/ui/markdown.css
+++ b/ui/markdown.css
@@ -748,8 +748,8 @@ main {
     position: absolute;
     z-index: 4;
     inset-block-end: 16px;
-    inset-inline-end: 18px;
-    max-width: calc(100% - 36px);
+    inset-inline-end: 66px;
+    max-width: calc(100% - 84px);
     flex-wrap: wrap;
     align-items: center;
     justify-content: flex-end;


### PR DESCRIPTION
## Summary

- stream selection translation text into the existing popup as provider output arrives
- ignore late deltas and clear partial text when a selection request is cancelled
- keep correction actions clear of the citation graph button
- update user documentation for streaming selection translations

## Verification

- `npm run check`
- `npm test` (1449 passed)
- `npm run build` (`build/mktero-0.3.4.xpi`)

The extension version remains `0.3.4`.