### PR TITLE
chore(deps): ignore marked 18.0.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       time: '03:00'
       timezone: Asia/Shanghai
     open-pull-requests-limit: 5
+    ignore:
+      # 18.0.11 makes repeated unmatched \[ delimiters parse in quadratic time.
+      - dependency-name: marked
+        versions:
+          - '18.0.11'
     groups:
       production-minor-and-patch:
         dependency-type: production


### PR DESCRIPTION
## Summary

- Keep `marked` pinned to `18.0.10` after the parser performance regression found in #100.
- Ignore only `marked@18.0.11` in Dependabot so the broken update is not proposed again.
- Preserve future `marked` updates for validation once an upstream fix is released.

## Verification

- Parsed `.github/dependabot.yml` and asserted the exact ignore rule.
- `node --test --test-name-pattern="handles many unmatched display delimiters in linear time" test/markdown-html.test.js`
- `npm run check`
- `npm test` (`1610/1610` passing)
- `npm run build`