### PR TITLE
fix: join split parentheticals and pack consecutive figures

### DIFF
--- a/src/editor/inline-rendering.js
+++ b/src/editor/inline-rendering.js
@@ -17,6 +17,7 @@ import { translateEnglish } from '../i18n/localization.js';
 import {
     findAcademicFigureGroups,
     findAcademicTableGroups,
+    findConsecutiveImagePacks,
 } from '../markdown/markdown-figures.js';
 import { analyzeMarkdownCitations } from '../markdown/markdown-citations.js';
 import {
@@ -894,17 +895,22 @@ function buildDecorations(state, context) {
         .filter(group => !rangesOverlapEditing(group, context));
     const figureGroups = findAcademicFigureGroups(state.doc.toString())
         .filter(group => !rangesOverlapEditing(group, context));
+    const imagePacks = findConsecutiveImagePacks(
+        state.doc.toString(),
+        figureGroups
+    ).filter(group => !rangesOverlapEditing(group, context));
+    const renderedFigureGroups = [...figureGroups, ...imagePacks];
     const tableGroups = findAcademicTableGroups(state.doc.toString())
         .filter(group => !rangesOverlapEditing(group, context));
     const renderedGroups = [
         ...algorithmGroups,
-        ...figureGroups,
+        ...renderedFigureGroups,
         ...tableGroups,
     ];
     for (const group of algorithmGroups) {
         decorations.push(renderedRange(group, state, 'algorithm', context));
     }
-    for (const group of figureGroups) {
+    for (const group of renderedFigureGroups) {
         decorations.push(renderedRange(group, state, 'image', context));
     }
     for (const group of tableGroups) {

--- a/src/markdown/markdown-figures.js
+++ b/src/markdown/markdown-figures.js
@@ -48,6 +48,7 @@ const MARKDOWN_HARD_BREAK_PATTERN = /[ \t]{2,}(?:\r?\n)?$/;
 // Both markers are Markdown hard breaks; the extra space records vertical layout.
 const MINERU_VERTICAL_PANEL_MARKER_SPACES = 3;
 const MAX_PANEL_LABEL_LENGTH = 80;
+const ISOLATED_PANEL_LETTER_PATTERN = /^[A-Za-z]\.?$/u;
 const FIGURE_LAYOUT_MARKER_PATTERN = /^<!--\s*(?:mktero-figure-layout|mktero-mistral-figure-grid):\s*columns=(\d{1,2})\s+rows=([\d,]{1,80})(?:\s+spans=([\d,]{1,256}))?\s*-->$/iu;
 
 export function parseFigureLayoutMarker(value) {
@@ -375,6 +376,88 @@ export function findAcademicFigureGroups(markdown) {
     }
 
     return groups;
+}
+
+export function findConsecutiveImagePacks(markdown, occupiedRanges = []) {
+    const source = String(markdown || '');
+    const lines = markdownLineRecords(source);
+    const blockedLines = findBlockedLines(lines);
+    const packs = [];
+
+    for (let index = 0; index < lines.length; index++) {
+        if (blockedLines.has(index)
+            || occupiedRanges.some(range => rangeContainsLine(range, lines[index]))) {
+            continue;
+        }
+        if (!isMarkdownImageLine(lines[index].raw)
+            && !isIsolatedPanelLetter(lines[index].raw)) {
+            continue;
+        }
+        const images = collectPackedImages(lines, index, blockedLines);
+        if (images.length < 2) continue;
+        if (images.some(image => captionFromImageLine(lines[image.index].raw))) {
+            continue;
+        }
+        if (images.some(image => occupiedRanges.some(range => (
+            rangeContainsLine(range, lines[image.index])
+        )))) {
+            continue;
+        }
+        const fromIndex = Number.isInteger(images[0].labelIndex)
+            ? images[0].labelIndex
+            : images[0].index;
+        packs.push({
+            from: lines[fromIndex].from,
+            to: lines[images.at(-1).index].to,
+            caption: null,
+            images,
+            layout: 'horizontal',
+        });
+        index = images.at(-1).index;
+    }
+
+    return packs;
+}
+
+function collectPackedImages(lines, startIndex, blockedLines) {
+    const images = [];
+    let index = nextNonBlankLine(lines, startIndex);
+    let pendingLabel = null;
+    let pendingLabelIndex = null;
+    while (index < lines.length && !blockedLines.has(index)) {
+        if (isIsolatedPanelLetter(lines[index].raw)) {
+            pendingLabel = lines[index].text.trim();
+            pendingLabelIndex = index;
+            index = nextNonBlankLine(lines, index + 1);
+            continue;
+        }
+        if (!isMarkdownImageLine(lines[index].raw)) break;
+        images.push({
+            index,
+            source: lines[index].text.trim(),
+            ...(pendingLabel ? {
+                panelLabel: pendingLabel,
+                panelLabelPosition: 'before',
+                labelIndex: pendingLabelIndex,
+            } : {}),
+        });
+        pendingLabel = null;
+        pendingLabelIndex = null;
+        const nextIndex = nextNonBlankLine(lines, index + 1);
+        if (nextIndex < lines.length
+            && (isMarkdownImageLine(lines[nextIndex].raw)
+                || isIsolatedPanelLetter(lines[nextIndex].raw))) {
+            index = nextIndex;
+            continue;
+        }
+        break;
+    }
+    return images;
+}
+
+function isIsolatedPanelLetter(line) {
+    const text = String(line || '').replace(/\r?\n$/, '').trim();
+    return ISOLATED_PANEL_LETTER_PATTERN.test(text);
 }
 
 function isEmptyImageLine(line) {

--- a/src/markdown/markdown-html.js
+++ b/src/markdown/markdown-html.js
@@ -8,6 +8,7 @@ import {
 import {
     findAcademicFigureGroups,
     findAcademicTableGroups,
+    findConsecutiveImagePacks,
     normalizeMisassignedAcademicCaptions,
     parseFigureLayoutMarker,
     parseAcademicFigureCaption,
@@ -181,8 +182,11 @@ function renderStandaloneAcademicFigureGroup(
     translate,
 ) {
     const groups = findAcademicFigureGroups(markdown);
-    if (groups.length !== 1) return null;
-    const group = groups[0];
+    const packs = groups.length === 1
+        ? groups
+        : findConsecutiveImagePacks(markdown);
+    if (packs.length !== 1) return null;
+    const group = packs[0];
     if (markdown.slice(0, group.from).trim()
         || markdown.slice(group.to).trim()) {
         return null;
@@ -299,6 +303,7 @@ function renderImageToken(
 }
 
 function renderFigureCaption(caption, mathBudget, tokens = null, target = 'mktero') {
+    if (!caption?.label) return '';
     return '<figcaption>'
         + `<span class="mktero-figure-label">${escapeHTML(caption.label)}</span>`
         + ` ${renderFigureCaptionDescription(caption, mathBudget, tokens, target)}`

--- a/src/mineru/markdown-normalizer.js
+++ b/src/mineru/markdown-normalizer.js
@@ -111,15 +111,18 @@ function isBrokenProseBoundary(previousBlock, separator, nextBlock) {
     }
     const continuesLoadReaction = LOAD_REACTION_MODIFIERS_END_PATTERN.test(previous)
         && LOAD_REACTIONS_START_PATTERN.test(next);
-    const continuesCitationYear = previous.endsWith(',')
-        && hasUnclosedParenthetical(previous)
+    const continuesUnclosedParenthetical = previous.endsWith(',')
+        && hasUnclosedParenthetical(previous);
+    const continuesCitationYear = continuesUnclosedParenthetical
         && CITATION_YEAR_CONTINUATION_PATTERN.test(next);
     const continuesProse = PROSE_CONTINUATION_END_PATTERN.test(previous)
         || continuesLoadReaction
-        || continuesCitationYear
+        || continuesUnclosedParenthetical
         || (previous.endsWith(';')
             && SEMICOLON_SERIES_CONTINUATION_PATTERN.test(next));
-    if ((!/^\p{Ll}/u.test(next) && !continuesCitationYear)
+    if ((!/^\p{Ll}/u.test(next)
+            && !continuesCitationYear
+            && !continuesUnclosedParenthetical)
         || !continuesProse) {
         return false;
     }

--- a/src/mineru/parser-profile.js
+++ b/src/mineru/parser-profile.js
@@ -13,6 +13,7 @@ export const MINERU_SOURCE_MAP_OPTIONS = Object.freeze({
     figurePanels: 'same-page-horizontal-or-labeled-vertical-ab-v2',
     figureLayouts: 'same-page-image-group-layout-v1',
     textFlow: 'cross-page-continuation-v1',
+    prose: 'unclosed-parenthetical-comma-v1',
     columns: 'same-page-two-column-reading-order-v3',
 });
 

--- a/test/inline-markdown-editor.test.js
+++ b/test/inline-markdown-editor.test.js
@@ -5711,6 +5711,44 @@ test('renders EvoBrain model notation inside its figure caption', () => {
     dom.window.close();
 });
 
+test('packs consecutive uncaptioned images and isolated panel letters into one figure', () => {
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const markdown = [
+        '![](images/a.png)',
+        '',
+        '',
+        '![](images/b.png)',
+        '',
+        'C',
+        '',
+        '![](images/c.png)',
+        '',
+        '![](images/d.png)',
+    ].join('\n');
+    const editor = createInlineMarkdownEditor({
+        document,
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+        resolveImageURL: path => `blob:mktero-${path}`,
+        openLink: () => {},
+    });
+
+    const figure = document.querySelector('.mktero-figure-group-horizontal');
+    assert.equal(figure?.querySelectorAll('img').length, 4);
+    assert.equal(
+        figure?.querySelector('.mktero-figure-panel-label')?.textContent,
+        'C'
+    );
+    assert.equal(document.querySelectorAll('.cm-mktero-image').length, 1);
+    assert.equal(editor.getMarkdown(), markdown);
+
+    editor.destroy();
+    dom.window.close();
+});
+
 test('renders one shared caption for consecutive MinerU figure panels', () => {
     const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
         pretendToBeVisual: true,

--- a/test/markdown-editor-styles.test.js
+++ b/test/markdown-editor-styles.test.js
@@ -295,7 +295,7 @@ test('keeps rendered figure spacing inside the CodeMirror block widget', () => {
     const figure = ruleBody(
         '.markdown-editor-host > .cm-editor .cm-mktero-image .mktero-figure'
     );
-    assert.match(figure, /margin:\s*24px 0 30px/);
+    assert.match(figure, /margin:\s*16px 0 18px/);
 });
 
 test('styles academic figure captions as distinct labels', () => {

--- a/test/mineru-markdown-normalizer.test.js
+++ b/test/mineru-markdown-normalizer.test.js
@@ -91,6 +91,31 @@ test('joins a MinerU paragraph split in the middle of a sentence', () => {
     );
 });
 
+test('joins a figure parenthetical split before an academic Methods locator', () => {
+    const markdown = 'Our intervention paradigm comprises three components: '
+        + 'evaluate whether a candidate direction can effectively correct the '
+        + 'model\'s answer within a bounded perturbation range (Fig. 4a,\n\n'
+        + 'Methods; extended explanation in Sec. S12). Smaller admissible '
+        + 'ranges indicate more precise directions.';
+
+    assert.equal(
+        normalizeMinerUMarkdown(markdown),
+        'Our intervention paradigm comprises three components: evaluate whether '
+            + 'a candidate direction can effectively correct the model\'s answer '
+            + 'within a bounded perturbation range (Fig. 4a, Methods; extended '
+            + 'explanation in Sec. S12). Smaller admissible ranges indicate more '
+            + 'precise directions.'
+    );
+});
+
+test('keeps a closed parenthetical separate from a following Methods paragraph', () => {
+    const markdown = 'A sufficiently detailed paragraph closes with a caveat '
+        + '(see Appendix A).\n\n'
+        + 'Methods were described independently in a follow-up document.';
+
+    assert.equal(normalizeMinerUMarkdown(markdown), markdown);
+});
+
 test('joins a citation year split from its preceding author name', () => {
     const markdown = 'Dental anxiety can stem from previous negative experiences '
         + '(Oosterink et al., 2008; van Houtem et al.,\n\n'

--- a/test/mineru-result.test.js
+++ b/test/mineru-result.test.js
@@ -19,6 +19,10 @@ test('includes figure panel reassembly in the MinerU parser profile', () => {
         'cross-page-continuation-v1'
     );
     assert.equal(
+        MINERU_SOURCE_MAP_OPTIONS.prose,
+        'unclosed-parenthetical-comma-v1'
+    );
+    assert.equal(
         MINERU_SOURCE_MAP_OPTIONS.columns,
         'same-page-two-column-reading-order-v3'
     );

--- a/ui/markdown.css
+++ b/ui/markdown.css
@@ -3531,14 +3531,18 @@ main {
     display: block;
     max-width: 100%;
     height: auto;
-    margin: 24px auto;
+    margin: 10px auto;
     border-radius: var(--radius-md);
     box-shadow: 0 0 0 1px var(--border-subtle);
 }
 
+.markdown-editor-host > .cm-editor .cm-mktero-image + .cm-mktero-image img {
+    margin-top: 4px;
+}
+
 .markdown-editor-host > .cm-editor .cm-mktero-image .mktero-figure {
     max-width: 100%;
-    margin: 24px 0 30px;
+    margin: 16px 0 18px;
 }
 
 .markdown-editor-host > .cm-editor .cm-mktero-image .mktero-figure img {


### PR DESCRIPTION
## Summary
- Join MinerU paragraphs that split academic asides such as `(Fig. 4a, Methods; …)` across a page break.
- Pack consecutive uncaptioned images (including stray `C` / `g` / `h` panel letters) into a compact horizontal figure in the reader.
- Tighten figure spacing. Image packing is render-only, so cached Markdown does not need a reparse; the parenthetical join does, via the parser profile bump.

## Test plan
- [ ] Install `build/mktero-0.3.5.xpi`
- [ ] Reparse *Beyond representational alignment…* and confirm `(Fig. 4a, Methods; …)` is one paragraph
- [ ] Open a multi-panel figure paper and confirm stacked a–h panels sit in a tighter grid
- [ ] Confirm papers without consecutive images are unchanged