### PR TITLE
fix: match Markdown annotations and render author-note daggers

### DIFF
--- a/src/core/markdown-annotation-overlay.js
+++ b/src/core/markdown-annotation-overlay.js
@@ -1,5 +1,6 @@
 import { findTextOccurrences } from '../markdown/text-normalization.js';
 import {
+    createDehyphenatedPdfAnnotationTextIndex,
     createHyphenFoldedPdfAnnotationTextIndex,
     createPdfAnnotationTextIndex,
     expandPdfAnnotationSourceRange,
@@ -70,6 +71,7 @@ export class MarkdownAnnotationOverlay {
         }
         const index = createVisibleMarkdownTextIndex(markdown);
         let normalizedIndex = null;
+        let dehyphenatedIndex = null;
         const matched = [];
         const unmatched = [];
         let previousSourceTo = 0;
@@ -178,10 +180,62 @@ export class MarkdownAnnotationOverlay {
                 previousSourceTo = Math.max(previousSourceTo, normalizedRange.to);
                 continue;
             }
+            const dehyphenatedText = createDehyphenatedPdfAnnotationTextIndex(
+                annotation.text
+            ).text;
+            if (!dehyphenatedIndex
+                && !candidates.length
+                && !normalizedCandidates.length) {
+                dehyphenatedIndex = createDehyphenatedPdfAnnotationTextIndex(
+                    index.text,
+                    offset => index.sourceOffsetAt(offset)
+                );
+            }
+            const dehyphenatedCandidateResult = candidates.length
+                || normalizedCandidates.length
+                ? { offsets: [], truncated: false }
+                : findTextOccurrences(
+                    dehyphenatedIndex.text,
+                    dehyphenatedText,
+                    MAX_MATCH_CANDIDATES
+                );
+            const dehyphenatedCandidates = dehyphenatedCandidateResult.offsets;
+            const dehyphenatedRanges = dehyphenatedCandidateResult.truncated
+                ? []
+                : dehyphenatedCandidates.map(candidate => (
+                    dehyphenatedIndex.sourceRange(
+                        candidate,
+                        dehyphenatedText.length
+                    )
+                ));
+            const dehyphenatedPageRanges = selectPageCandidates(
+                dehyphenatedRanges,
+                annotation.pageIndex,
+                sourceMap,
+                markdown.length
+            );
+            const dehyphenatedRange = selectCandidateRange(
+                dehyphenatedPageRanges,
+                previousSourceTo
+            );
+            if (dehyphenatedRange) {
+                matched.push(resolvedAnnotation(
+                    annotation,
+                    'normalized',
+                    dehyphenatedRange
+                ));
+                previousSourceTo = Math.max(
+                    previousSourceTo,
+                    dehyphenatedRange.to
+                );
+                continue;
+            }
             const ambiguous = candidateResult.truncated
                 || candidates.length
                 || normalizedCandidateResult.truncated
-                || normalizedCandidates.length;
+                || normalizedCandidates.length
+                || dehyphenatedCandidateResult.truncated
+                || dehyphenatedCandidates.length;
             unmatched.push({
                 ...annotation,
                 reason: ambiguous ? 'ambiguous' : 'not-found',

--- a/src/core/markdown-local-annotations.js
+++ b/src/core/markdown-local-annotations.js
@@ -7,7 +7,10 @@ import {
     normalizePDFAnnotationTextQuote,
     trailingCodePoints,
 } from './pdf-annotation.js';
-import { createVisibleMarkdownTextIndex } from '../markdown/markdown-visible-text.js';
+import {
+    createVisibleMarkdownTextIndex,
+    visibleMarkdownTextForRanges,
+} from '../markdown/markdown-visible-text.js';
 import { findTextOccurrences } from '../markdown/text-normalization.js';
 import {
     createPdfAnnotationTextIndex,
@@ -583,10 +586,9 @@ export function markdownAnnotationRangeMatchesSource(markdown, rangeOrRanges, te
         || ranges.some(range => !validRange(range, source.length))) {
         return false;
     }
-    const visible = ranges.map(range => (
-        createVisibleMarkdownTextIndex(source.slice(range.from, range.to)).text
-    )).join('');
-    return normalizeVisibleText(visible) === normalizeVisibleText(text);
+    return normalizeVisibleText(
+        visibleMarkdownTextForRanges(source, ranges)
+    ) === normalizeVisibleText(text);
 }
 
 export function createMarkdownAnnotationTextQuote(

--- a/src/core/markdown-source-map.js
+++ b/src/core/markdown-source-map.js
@@ -328,17 +328,90 @@ export function resolvePDFPageIndexHint(
         range,
         documentLength
     );
-    if (!match) return null;
-    const rangeLocation = resolveSourceMapLocation(
-        match,
-        range,
-        documentLength
+    if (match) {
+        const rangeLocation = resolveSourceMapLocation(
+            match,
+            range,
+            documentLength
+        );
+        if (rangeLocation) return rangeLocation.pageIndex;
+        return uniqueSourceMapEntryPage(match);
+    }
+    const overlappingPages = uniqueSourceMapPages(
+        overlappingSourceMapEntries(sourceMap, range, documentLength)
     );
-    if (rangeLocation) return rangeLocation.pageIndex;
-    const pageIndex = match.locations[0].pageIndex;
-    return match.locations.every(location => location.pageIndex === pageIndex)
+    if (overlappingPages.length === 1) return overlappingPages[0];
+    if (overlappingPages.length > 1) return null;
+    const nearestPages = uniqueSourceMapPages(
+        nearestSourceMapEntries(sourceMap, range, documentLength)
+    );
+    return nearestPages.length === 1 ? nearestPages[0] : null;
+}
+
+function overlappingSourceMapEntries(sourceMap, range, documentLength) {
+    if (!Array.isArray(sourceMap) || !isValidDocumentRange(range, documentLength)) {
+        return [];
+    }
+    return sourceMap.filter(entry => (
+        isValidSourceMapEntry(entry, documentLength)
+        && entry.markdownFrom < range.to
+        && entry.markdownTo > range.from
+    ));
+}
+
+function nearestSourceMapEntries(sourceMap, range, documentLength) {
+    if (!Array.isArray(sourceMap) || !isValidDocumentRange(range, documentLength)) {
+        return [];
+    }
+    let bestDistance = Infinity;
+    const nearest = [];
+    for (const entry of sourceMap) {
+        if (!isValidSourceMapEntry(entry, documentLength)) continue;
+        const distance = sourceMapRangeDistance(range, entry);
+        if (distance < bestDistance) {
+            bestDistance = distance;
+            nearest.length = 0;
+            nearest.push(entry);
+        }
+        else if (distance === bestDistance) {
+            nearest.push(entry);
+        }
+    }
+    return nearest;
+}
+
+function sourceMapRangeDistance(range, entry) {
+    if (entry.markdownFrom < range.to && entry.markdownTo > range.from) {
+        return 0;
+    }
+    if (range.from >= entry.markdownTo) return range.from - entry.markdownTo;
+    return entry.markdownFrom - range.to;
+}
+
+function uniqueSourceMapPages(entries) {
+    const pages = new Set();
+    for (const entry of entries) {
+        const pageIndex = uniqueSourceMapEntryPage(entry);
+        if (pageIndex === null) return [];
+        pages.add(pageIndex);
+    }
+    return [...pages];
+}
+
+function uniqueSourceMapEntryPage(entry) {
+    const pageIndex = entry?.locations?.[0]?.pageIndex;
+    if (!Number.isSafeInteger(pageIndex) || pageIndex < 0) return null;
+    return entry.locations.every(location => location.pageIndex === pageIndex)
         ? pageIndex
         : null;
+}
+
+function isValidDocumentRange(range, documentLength) {
+    return Number.isSafeInteger(range?.from)
+        && Number.isSafeInteger(range?.to)
+        && range.from >= 0
+        && range.to > range.from
+        && range.to <= documentLength;
 }
 
 export function resolveSourceMapLocation(

--- a/src/editor/inline-rendering.js
+++ b/src/editor/inline-rendering.js
@@ -19,7 +19,10 @@ import {
     findAcademicTableGroups,
     findConsecutiveImagePacks,
 } from '../markdown/markdown-figures.js';
-import { analyzeMarkdownCitations } from '../markdown/markdown-citations.js';
+import {
+    analyzeMarkdownCitations,
+    findAuthorNoteLatexCommands,
+} from '../markdown/markdown-citations.js';
 import {
     analyzeMarkdownFigureReferences,
 } from '../markdown/markdown-figure-references.js';
@@ -52,9 +55,11 @@ import {
 import { MAX_PDF_ANNOTATION_TEXT_LENGTH } from '../core/pdf-annotation.js';
 import {
     subtractChromeRanges,
-    visibleTextForRanges,
 } from '../markdown/chrome-ranges.js';
-import { createVisibleMarkdownTextIndex } from '../markdown/markdown-visible-text.js';
+import {
+    createVisibleMarkdownTextIndex,
+    visibleMarkdownTextForRanges,
+} from '../markdown/markdown-visible-text.js';
 import {
     findTextOccurrences,
     isNumericCitationContent,
@@ -1664,7 +1669,10 @@ export function selectedMarkdownAnnotation(view, chromeRanges = []) {
 function annotationSelectionWithoutChrome(view, from, to, chromeRanges) {
     const ranges = subtractChromeRanges({ from, to }, chromeRanges);
     if (!ranges.length) return null;
-    const text = visibleTextForRanges(view.state.doc.toString(), ranges).trim();
+    const text = visibleMarkdownTextForRanges(
+        view.state.doc.toString(),
+        ranges
+    ).trim();
     if (!text || text.length > MAX_PDF_ANNOTATION_TEXT_LENGTH) return null;
     return { text, ranges };
 }
@@ -2317,6 +2325,64 @@ function decorateMath(
         ));
         renderedMathRanges.push({ from: matchFrom, to: matchTo });
     }
+
+    decorateAuthorNoteLatexCommands(
+        source,
+        node.from,
+        state,
+        decorations,
+        excludedRanges,
+        renderedMathRanges,
+        context
+    );
+}
+
+function decorateAuthorNoteLatexCommands(
+    source,
+    nodeFrom,
+    state,
+    decorations,
+    excludedRanges,
+    renderedMathRanges,
+    context
+) {
+    for (const match of findAuthorNoteLatexCommands(source)) {
+        const matchFrom = nodeFrom + match.start;
+        const matchTo = nodeFrom + match.end;
+        if (rangeOverlapsAny(matchFrom, matchTo, excludedRanges)
+            || rangeOverlapsAny(matchFrom, matchTo, renderedMathRanges)) {
+            continue;
+        }
+        decorations.push(renderedMathRange(
+            match.raw,
+            matchFrom,
+            matchTo,
+            'math',
+            context,
+            true,
+            authorNoteLatexClassName(state, context, matchFrom, matchTo),
+            `$${match.raw}$`
+        ));
+        renderedMathRanges.push({ from: matchFrom, to: matchTo });
+    }
+}
+
+function authorNoteLatexClassName(state, context, from, to) {
+    const result = citationAnalysis(state, context);
+    const markups = [
+        ...result.citations.map(citation => citation.superscriptMarkup),
+        ...result.affiliations.map(affiliation => affiliation.markerMarkup),
+    ].filter(Boolean);
+    for (const markup of markups) {
+        if (!markup.raiseContent) continue;
+        if (from >= markup.contentFrom && to <= markup.contentTo) {
+            return 'cm-mktero-citation-superscript';
+        }
+        if (from === markup.wrapperTo) {
+            return 'cm-mktero-citation-superscript';
+        }
+    }
+    return '';
 }
 
 function hasSuperscriptCitationMarkup(state, context, from, to) {
@@ -2708,11 +2774,13 @@ function renderedMathRange(
     display,
     context,
     inline = false,
-    extraClassName = ''
+    extraClassName = '',
+    renderSource = source
 ) {
     return Decoration.replace({
         widget: new RenderedMarkdownWidget({
             source,
+            renderSource,
             display,
             from,
             annotations: annotationsOverlappingRange(

--- a/src/markdown/markdown-citations.js
+++ b/src/markdown/markdown-citations.js
@@ -23,7 +23,12 @@ const WRAPPED_SUPERSCRIPT_PATTERNS = [
     /\$(?:\{\})?\^\{\s*([^{}\r\n]{1,80}?)\s*\}\$/g,
     /\\\((?:\{\})?\^\{\s*([^{}\r\n]{1,80}?)\s*\}\\\)/g,
 ];
-const AUTHOR_NOTE_DECORATED_AFFILIATION_PATTERN = /^([*†‡§¶#+‖]*)(\d+|\p{L})([*†‡§¶#+‖]*)$/u;
+const AUTHOR_NOTE_MARK_PATTERN = '(?:[*†‡§¶#+‖]|\\\\(?:dagger|ddagger|dag|ddag)(?![A-Za-z]))';
+const AUTHOR_NOTE_DECORATED_AFFILIATION_PATTERN = new RegExp(
+    `^(${AUTHOR_NOTE_MARK_PATTERN}*)(\\d+|\\p{L})(${AUTHOR_NOTE_MARK_PATTERN}*)$`,
+    'u'
+);
+const AUTHOR_NOTE_LATEX_COMMAND_PATTERN = /\\(?:dagger|ddagger|dag|ddag)(?![A-Za-z])/g;
 const UNICODE_SUPERSCRIPT_CHARACTERS = {
     '⁰': '0',
     '¹': '1',
@@ -37,6 +42,35 @@ const UNICODE_SUPERSCRIPT_CHARACTERS = {
     '⁹': '9',
     '⁻': '-',
 };
+
+export function findAuthorNoteLatexCommands(source) {
+    const text = String(source || '');
+    const commands = [];
+    for (const match of text.matchAll(AUTHOR_NOTE_LATEX_COMMAND_PATTERN)) {
+        if (isEscapedAuthorNoteCommand(text, match.index)) continue;
+        const end = match.index + match[0].length;
+        const previous = commands.at(-1);
+        if (previous && previous.end === match.index) {
+            previous.end = end;
+            previous.raw += match[0];
+            continue;
+        }
+        commands.push({
+            start: match.index,
+            end,
+            raw: match[0],
+        });
+    }
+    return commands;
+}
+
+function isEscapedAuthorNoteCommand(source, index) {
+    let backslashes = 0;
+    for (let cursor = index - 1; cursor >= 0 && source[cursor] === '\\'; cursor--) {
+        backslashes++;
+    }
+    return backslashes % 2 === 1;
+}
 
 export function analyzeMarkdownCitations(markdown) {
     const source = String(markdown || '');

--- a/src/markdown/markdown-visible-text.js
+++ b/src/markdown/markdown-visible-text.js
@@ -1,5 +1,8 @@
 import { GFM, parser } from '@lezer/markdown';
-import { findInlineMathMatches } from './markdown-html.js';
+import {
+    findDisplayMathMatches,
+    findInlineMathMatches,
+} from './markdown-html.js';
 import { isNumericCitationContent } from './text-normalization.js';
 
 const MARKDOWN_PARSER = parser.configure(GFM);
@@ -116,6 +119,39 @@ export function createVisibleMarkdownTextIndex(markdown, extraHiddenRanges = [])
             return output.join('');
         },
     };
+}
+
+export function visibleMarkdownTextForRanges(markdown, ranges) {
+    const source = String(markdown || '');
+    if (!Array.isArray(ranges)) return '';
+    return ranges.map(range => {
+        if (!Number.isInteger(range?.from)
+            || !Number.isInteger(range?.to)
+            || range.from < 0
+            || range.to <= range.from
+            || range.to > source.length) {
+            return '';
+        }
+        return visibleTextForMarkdownSlice(source.slice(range.from, range.to));
+    }).join('');
+}
+
+function visibleTextForMarkdownSlice(source) {
+    const display = findDisplayMathMatches(source);
+    if (coversWholeSource(source, display[0])) {
+        return display[0].text;
+    }
+    const inline = findInlineMathMatches(source);
+    if (coversWholeSource(source, inline[0]) && !inline[0].text.startsWith('^')) {
+        return inline[0].text;
+    }
+    return createVisibleMarkdownTextIndex(source).text;
+}
+
+function coversWholeSource(source, match) {
+    return Boolean(match)
+        && !source.slice(0, match.start).trim()
+        && !source.slice(match.end).trim();
 }
 
 function collectHiddenRanges(markdown, extraHiddenRanges = []) {

--- a/src/markdown/pdf-annotation-text.js
+++ b/src/markdown/pdf-annotation-text.js
@@ -20,7 +20,9 @@ const SIGNED_NUMBER_WHITESPACE_PATTERN = /(?:[+\-−±]|(?<!\\)\\pm)(\s+)(?=\d)/
 const DEGREE_SYMBOL_WHITESPACE_PATTERN = /([\p{N})\]}])(\s+)(?=°)/gu;
 const DEGREE_SYMBOL_UNIT_WHITESPACE_PATTERN = /°(\s+)(?=\p{L})/gu;
 const LATEX_TEXT_UNIT_PATTERN = /(?<!\\)\\mathrm\{([A-Za-z]{1,32})\}/gu;
-const LATEX_BRACED_SUBSCRIPT_PATTERN = /(?<!\\)_\{([A-Za-z0-9][A-Za-z0-9,.;:+-]{0,63})\}/gu;
+const LATEX_BRACED_SUBSCRIPT_PATTERN = /(?<!\\)_[ \t]*\{[ \t]*([A-Za-z0-9][A-Za-z0-9,.;:+-]{0,63})[ \t]*\}/gu;
+const LATEX_TAG_PATTERN = /(?<!\\)\\tag\{([^}]{0,32})\}/gu;
+const EQUATION_NUMBER_WHITESPACE_PATTERN = /,(\s+)(?=\(\d{1,4}\))/gu;
 const LATEX_SINGLE_SUBSCRIPT_PATTERN = /(?<!\\)_([A-Za-z0-9])/gu;
 const LATEX_MATH_COMMAND_NAMES = new Set([
     'alpha',
@@ -129,6 +131,7 @@ const MATH_SYMBOL_CANONICAL_FORMS = new Map([
     ['ϱ', 'ρ'],
     ['ς', 'σ'],
     ['ϕ', 'φ'],
+    ['∆', 'Δ'],
 ]);
 const ALL_PDF_ANNOTATION_SYMBOL_REPLACEMENTS = [
     ...PDF_ANNOTATION_SYMBOL_REPLACEMENTS,
@@ -174,8 +177,16 @@ export function createPdfAnnotationTextIndex(
     );
 }
 
-export function createDehyphenatedPdfAnnotationTextIndex(text) {
-    return createLineWrappedPdfAnnotationTextIndex(text, false);
+export function createDehyphenatedPdfAnnotationTextIndex(
+    text,
+    sourceOffsetAt = offset => offset
+) {
+    return createLineWrappedPdfAnnotationTextIndex(
+        text,
+        false,
+        false,
+        sourceOffsetAt
+    );
 }
 
 export function createHyphenPreservingPdfAnnotationTextIndex(text) {
@@ -189,9 +200,13 @@ export function createHyphenFoldedPdfAnnotationTextIndex(text) {
 function createLineWrappedPdfAnnotationTextIndex(
     text,
     preserveHyphen,
-    foldLexicalHyphens = false
+    foldLexicalHyphens = false,
+    sourceOffsetAt = offset => offset
 ) {
-    const normalized = createPdfAnnotationTextIndex(String(text));
+    const normalized = createPdfAnnotationTextIndex(
+        String(text),
+        sourceOffsetAt
+    );
     const output = [];
     const sourceStarts = [];
     const sourceEnds = [];
@@ -303,6 +318,7 @@ function collectNormalizationMarkup(text) {
     const replacements = new Map();
     markAnnotationSymbols(text, ignoredOffsets, replacements);
     markLatexSubscripts(text, ignoredOffsets, replacements);
+    markLatexTags(text, ignoredOffsets, replacements);
     markStatisticalNumericExponents(text, ignoredOffsets, replacements);
     markMathematicalWhitespace(text, ignoredOffsets);
     for (const match of text.matchAll(CITATION_WRAPPER)) {
@@ -439,6 +455,19 @@ function markAnnotationSymbols(text, ignoredOffsets, replacements) {
                 match.index + 1,
                 match[0].length - 1
             );
+            let spaceFrom = match.index + match[0].length;
+            let spaceTo = spaceFrom;
+            while (spaceTo < text.length && /[ \t]/u.test(text[spaceTo])) {
+                spaceTo++;
+            }
+            if (spaceTo > spaceFrom
+                && (text[spaceTo] === '\\' || text[spaceTo] === '_')) {
+                markOffsetRange(
+                    ignoredOffsets,
+                    spaceFrom,
+                    spaceTo - spaceFrom
+                );
+            }
         }
     }
     for (const match of text.matchAll(LATEX_TEXT_UNIT_PATTERN)) {
@@ -462,6 +491,18 @@ function markLatexSubscripts(text, ignoredOffsets, replacements) {
     ]) {
         for (const match of text.matchAll(pattern)) {
             if (!isLikelyLatexSubscript(text, match.index)) continue;
+            let spaceFrom = match.index;
+            while (spaceFrom > 0 && /[ \t]/u.test(text[spaceFrom - 1])) {
+                spaceFrom--;
+            }
+            if (spaceFrom < match.index
+                && /[\p{L}\p{N})\]}]/u.test(text[spaceFrom - 1] || '')) {
+                markOffsetRange(
+                    ignoredOffsets,
+                    spaceFrom,
+                    match.index - spaceFrom
+                );
+            }
             replacements.set(match.index, {
                 from: match.index,
                 to: match.index + match[0].length,
@@ -471,6 +512,34 @@ function markLatexSubscripts(text, ignoredOffsets, replacements) {
                 ignoredOffsets,
                 match.index + 1,
                 match[0].length - 1
+            );
+        }
+    }
+}
+
+function markLatexTags(text, ignoredOffsets, replacements) {
+    for (const match of text.matchAll(LATEX_TAG_PATTERN)) {
+        const label = String(match[1] || '').trim();
+        if (!label) continue;
+        replacements.set(match.index, {
+            from: match.index,
+            to: match.index + match[0].length,
+            text: `(${label})`,
+        });
+        markOffsetRange(
+            ignoredOffsets,
+            match.index + 1,
+            match[0].length - 1
+        );
+        let spaceFrom = match.index;
+        while (spaceFrom > 0 && /[ \t]/u.test(text[spaceFrom - 1])) {
+            spaceFrom--;
+        }
+        if (spaceFrom < match.index) {
+            markOffsetRange(
+                ignoredOffsets,
+                spaceFrom,
+                match.index - spaceFrom
             );
         }
     }
@@ -487,8 +556,20 @@ function isLikelyLatexSubscript(text, offset) {
             || command.name === 'text'
         );
     }
-    // Braces are the unambiguous LaTeX form, even when the base is a word.
-    return text[offset + 1] === '{';
+    let next = offset + 1;
+    while (next < text.length && /[ \t]/u.test(text[next])) next++;
+    if (text[next] === '{') return true;
+    if (!/^[A-Za-z0-9]$/u.test(text[next] || '')) return false;
+    if (next + 1 < text.length && /[A-Za-z0-9]/u.test(text[next + 1])) {
+        return false;
+    }
+    let previous = offset;
+    while (previous > 0 && /[ \t]/u.test(text[previous - 1])) previous--;
+    if (previous <= 0) return false;
+    const previousOffset = previousCodePointOffset(text, previous);
+    return isPdfAnnotationMathLetter(
+        String.fromCodePoint(text.codePointAt(previousOffset))
+    );
 }
 
 function latexCommandAtEnd(prefix) {
@@ -512,12 +593,55 @@ function normalizeMathSymbolText(text) {
     )).join('');
 }
 
+function isPdfAnnotationMathLetter(character) {
+    const mapped = MATH_SYMBOL_CANONICAL_FORMS.get(character)
+        || MATH_SYMBOL_CANONICAL_FORMS.get(character.normalize('NFKC'))
+        || character.normalize('NFKC');
+    return /^\p{Script=Greek}$/u.test(mapped);
+}
+
+function markMathLetterWhitespace(text, ignoredOffsets) {
+    for (let offset = 0; offset < text.length;) {
+        const character = String.fromCodePoint(text.codePointAt(offset));
+        const nextOffset = offset + character.length;
+        if (!/^\s$/u.test(character)) {
+            offset = nextOffset;
+            continue;
+        }
+        let end = nextOffset;
+        while (end < text.length && /^\s$/u.test(text[end])) end++;
+        let previous = offset;
+        while (previous > 0 && /[ \t]/u.test(text[previous - 1])) previous--;
+        const before = previous > 0
+            ? String.fromCodePoint(
+                text.codePointAt(previousCodePointOffset(text, previous))
+            )
+            : '';
+        const after = end < text.length
+            ? String.fromCodePoint(text.codePointAt(end))
+            : '';
+        if (isPdfAnnotationMathLetter(before)
+            && isPdfAnnotationMathLetter(after)) {
+            markOffsetRange(ignoredOffsets, offset, end - offset);
+        }
+        offset = end;
+    }
+}
+
 function markMathematicalWhitespace(text, ignoredOffsets) {
+    markMathLetterWhitespace(text, ignoredOffsets);
     for (const pattern of [
         RELATIONAL_OPERATOR_PATTERN,
         LATEX_RELATIONAL_OPERATOR_PATTERN,
     ]) {
         markRelationalOperatorWhitespace(text, pattern, ignoredOffsets);
+    }
+    for (const match of text.matchAll(EQUATION_NUMBER_WHITESPACE_PATTERN)) {
+        markOffsetRange(
+            ignoredOffsets,
+            match.index + 1,
+            match[1].length
+        );
     }
     for (const match of text.matchAll(
         OPENING_DELIMITER_SIGNED_NUMBER_WHITESPACE_PATTERN

--- a/test/inline-markdown-editor.test.js
+++ b/test/inline-markdown-editor.test.js
@@ -1318,6 +1318,52 @@ test('shows one note marker when an annotation covers formula content', () => {
     dom.window.close();
 });
 
+test('highlights a display math formula covered by an annotation', () => {
+    const formula = 'A_t = (P, \\Sigma_t, O_t)';
+    const markdown = [
+        'Intro paragraph.',
+        '',
+        '$$',
+        formula,
+        '$$',
+        '',
+        'Body paragraph.',
+    ].join('\n');
+    const from = markdown.indexOf('$$');
+    const to = markdown.lastIndexOf('$$') + 2;
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: '',
+        resolveImageURL: () => null,
+    });
+    editor.setDocument({
+        markdown,
+        annotationOverlay: {
+            matched: [{
+                id: 'MATHDISP1',
+                type: 'highlight',
+                text: formula,
+                color: '#ffd400',
+                ranges: [{ from, to }],
+            }],
+            unmatched: [],
+        },
+    });
+
+    const highlight = document.querySelector(
+        '.cm-mktero-math-display .cm-mktero-pdf-annotation--highlight'
+    );
+    assert.ok(highlight);
+    assert.match(highlight.getAttribute('style') || '', /#ffd400/i);
+
+    editor.destroy();
+    dom.window.close();
+});
+
 test('edits PDF annotation notes safely after clicking the note marker', async () => {
     const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
         pretendToBeVisual: true,
@@ -5346,6 +5392,62 @@ test('links affiliations after leading equal-contribution and corresponding-auth
     );
     assert.equal(citations[0].getAttribute('aria-label'), 'View author affiliation 1');
     assert.equal(citations.at(-1).getAttribute('aria-label'), 'View author affiliation 2');
+    assert.equal(editor.getMarkdown(), markdown);
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('renders latex daggers in author superscripts with KaTeX', () => {
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const markdown = [
+        '# Repo-To-Skill',
+        '',
+        'Jianyu Chen $^{1,2\\dagger\\dagger}$, Hongjin Qian $^{1}$\\dagger',
+        '',
+        '$^{1}$ Beijing Academy of Artificial Intelligence',
+        '',
+        '$^{2}$ Renmin University of China',
+        '',
+        '## Abstract',
+        '',
+        'Body text.',
+    ].join('\n');
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+    });
+    const authorLine = [...document.querySelectorAll('.cm-line')]
+        .find(line => line.textContent.includes('Jianyu Chen'));
+    const math = [...authorLine.querySelectorAll('.cm-mktero-math')];
+    const visibleMath = math.map(widget => {
+        const clone = widget.cloneNode(true);
+        for (const annotation of clone.querySelectorAll('annotation')) {
+            annotation.remove();
+        }
+        return clone.textContent;
+    });
+
+    assert.ok(authorLine);
+    assert.equal(math.length, 2);
+    assert.ok(math.every(widget => widget.querySelector('math')));
+    assert.ok(math.every(widget => (
+        widget.classList.contains('cm-mktero-citation-superscript')
+    )));
+    assert.deepEqual(
+        math.map(widget => widget.querySelector('annotation')?.textContent),
+        ['\\dagger\\dagger', '\\dagger']
+    );
+    assert.ok(visibleMath.every(text => text.includes('†')));
+    assert.ok(visibleMath.every(text => !text.includes('\\dagger')));
+    assert.deepEqual(
+        [...authorLine.querySelectorAll('.cm-mktero-citation')]
+            .map(citation => citation.textContent),
+        ['1', '2', '1']
+    );
     assert.equal(editor.getMarkdown(), markdown);
 
     editor.destroy();

--- a/test/markdown-annotation-overlay.test.js
+++ b/test/markdown-annotation-overlay.test.js
@@ -605,6 +605,54 @@ test('matches PDF citation digits against inline MinerU superscripts', async () 
     assert.deepEqual(result.unmatched, []);
 });
 
+test('matches PDF highlights split by a line-end hyphen', async () => {
+    const markdown = [
+        'Current LLM agent runtimes execute procedural skills by repeatedly',
+        ' appending reasoning traces, actions, observations, and tool outputs',
+        ' to a growing conversational history. Consequently, the execution',
+        ' state is represented implicitly within natural language and must be',
+        ' reconstructed by the language model at every interaction.',
+    ].join('');
+    const annotations = [{
+        id: 'HYPHEN01',
+        type: 'highlight',
+        text: 'Current LLM agent runtimes execute procedural skills by repeatedly appending reasoning traces, ac- tions, observations, and tool outputs to a growing conversational history.',
+        comment: '',
+        color: '#ff6666',
+        pageLabel: '2',
+        pageIndex: 1,
+        sortIndex: '00002',
+    }, {
+        id: 'HYPHEN02',
+        type: 'highlight',
+        text: 'state is represented implicitly within natural lan- guage and must be reconstructed by the language model at every interaction.',
+        comment: '',
+        color: '#ff6666',
+        pageLabel: '3',
+        pageIndex: 2,
+        sortIndex: '00003',
+    }];
+    const overlay = new MarkdownAnnotationOverlay({
+        extractor: { extract: async () => annotations },
+    });
+
+    const result = await overlay.resolve(42, markdown);
+    const first = annotations[0].text.replace('ac- tions', 'actions');
+    const second = annotations[1].text.replace('lan- guage', 'language');
+
+    assert.deepEqual(result.unmatched, []);
+    assert.equal(result.matched[0].id, 'HYPHEN01');
+    assert.equal(markdown.slice(
+        result.matched[0].ranges[0].from,
+        result.matched[0].ranges[0].to
+    ), first);
+    assert.equal(result.matched[1].id, 'HYPHEN02');
+    assert.equal(markdown.slice(
+        result.matched[1].ranges[0].from,
+        result.matched[1].ranges[0].to
+    ), second);
+});
+
 test('does not flatten ordinary numeric superscript math into PDF text', async () => {
     const annotation = {
         id: 'MATH0002',

--- a/test/markdown-annotation-selection.test.js
+++ b/test/markdown-annotation-selection.test.js
@@ -1,0 +1,319 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { JSDOM } from 'jsdom';
+import { createInlineMarkdownEditor } from '../src/editor/inline-markdown-editor.js';
+import {
+    collectMarkdownTranslationBlocks,
+    createDocumentTranslationViews,
+    mapComparisonRangeToSource,
+} from '../src/markdown/markdown-translation-blocks.js';
+import { markdownAnnotationRangeMatchesSource } from '../src/core/markdown-local-annotations.js';
+
+function textNodeContaining(element, text) {
+    const walker = element.ownerDocument.createTreeWalker(
+        element,
+        element.ownerDocument.defaultView.NodeFilter.SHOW_TEXT
+    );
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+        if (node.textContent.includes(text)) return node;
+    }
+    return null;
+}
+
+function selectAndHighlight(document, ownerWindow, target, color = '#2ea8e5') {
+    const range = document.createRange();
+    if (typeof target === 'function') {
+        target(range);
+    }
+    else {
+        range.selectNodeContents(target);
+    }
+    document.getSelection().removeAllRanges();
+    document.getSelection().addRange(range);
+    const eventTarget = target.nodeType ? target : document.querySelector('.cm-content');
+    eventTarget.dispatchEvent(new ownerWindow.MouseEvent('mouseup', {
+        bubbles: true,
+        button: 0,
+    }));
+    const actions = document.querySelector('.mktero-markdown-selection-actions');
+    assert.ok(actions);
+    actions.querySelector(`[data-color="${color}"]`).click();
+    return actions;
+}
+
+test('creates a local highlight from a whole heading line without Markdown marks', async () => {
+    const markdown = '### 3.1 Execution State and Schema Authoring\n\nBody paragraph.';
+    const created = [];
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: markdown,
+        createMarkdownAnnotation: async annotation => {
+            created.push(annotation);
+            return annotation;
+        },
+    });
+    const line = [...document.querySelectorAll('.cm-line')].find(candidate => (
+        candidate.textContent.includes('3.1 Execution State')
+    ));
+    assert.ok(line);
+    selectAndHighlight(document, dom.window, line);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(created.length, 1);
+    assert.equal(created[0].text, '3.1 Execution State and Schema Authoring');
+    assert.deepEqual(created[0].ranges, [{ from: 0, to: 44 }]);
+    assert.equal(
+        markdownAnnotationRangeMatchesSource(
+            markdown,
+            created[0].ranges,
+            created[0].text
+        ),
+        true
+    );
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('creates a bilingual highlight from a display math formula', async () => {
+    const formula = '(R_t, \\Delta\\Sigma_t, a_t)';
+    const markdown = [
+        'Given the current execution context.',
+        '',
+        '$$',
+        formula,
+        '$$',
+        '',
+        'where R_t denotes the trace.',
+    ].join('\n');
+    const blocks = collectMarkdownTranslationBlocks(markdown);
+    const translations = blocks.filter(block => block.translatable).map(block => ({
+        id: block.id,
+        markdown: `${block.markdown} 译文。`,
+    }));
+    const views = createDocumentTranslationViews(markdown, blocks, translations);
+    const created = [];
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: '',
+        createMarkdownAnnotation: async (annotation, selectionContext) => {
+            const ranges = annotation.ranges.map(range => (
+                mapComparisonRangeToSource(range, views.blockRanges)
+            ));
+            created.push({ annotation, selectionContext, ranges });
+            return annotation;
+        },
+    });
+    editor.setDocument({
+        markdown: views.comparisonMarkdown,
+        sourceActionRanges: views.blockRanges.flatMap(range => (
+            Number.isSafeInteger(range.comparisonSourceFrom)
+                && Number.isSafeInteger(range.comparisonSourceTo)
+                && range.comparisonSourceTo > range.comparisonSourceFrom
+                ? [{
+                    from: range.comparisonSourceFrom,
+                    to: range.comparisonSourceTo,
+                }]
+                : []
+        )),
+        translationPairs: views.blockRanges.map(range => ({
+            id: range.id,
+            sourceFrom: range.comparisonSourceFrom,
+            sourceTo: range.comparisonSourceTo,
+            translatedFrom: range.comparisonTranslationFrom,
+            translatedTo: range.comparisonTranslationTo,
+        })),
+        translationRanges: views.comparisonTranslationRanges,
+    });
+
+    const math = document.querySelector('.cm-mktero-math-display');
+    assert.ok(math);
+    selectAndHighlight(document, dom.window, math);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(created.length, 1);
+    assert.equal(created[0].selectionContext.side, 'source');
+    assert.equal(created[0].annotation.text, formula);
+    assert.ok(created[0].ranges.every(Boolean));
+    assert.equal(
+        markdownAnnotationRangeMatchesSource(
+            markdown,
+            created[0].ranges,
+            created[0].annotation.text
+        ),
+        true
+    );
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('creates a bilingual heading highlight that maps back to original Markdown', async () => {
+    const markdown = '### 3.1 Execution State and Schema Authoring\n\nBody paragraph.';
+    const blocks = collectMarkdownTranslationBlocks(markdown);
+    const views = createDocumentTranslationViews(markdown, blocks, [{
+        id: blocks[0].id,
+        markdown: '### 3.1 执行状态与模式设计',
+    }, {
+        id: blocks[1].id,
+        markdown: '正文。',
+    }]);
+    const created = [];
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: '',
+        createMarkdownAnnotation: async (annotation, selectionContext) => {
+            const ranges = annotation.ranges.map(range => (
+                mapComparisonRangeToSource(range, views.blockRanges)
+            ));
+            created.push({ annotation, selectionContext, ranges });
+            return annotation;
+        },
+    });
+    editor.setDocument({
+        markdown: views.comparisonMarkdown,
+        sourceActionRanges: views.blockRanges.map(range => ({
+            from: range.comparisonSourceFrom,
+            to: range.comparisonSourceTo,
+        })),
+        translationPairs: views.blockRanges.map(range => ({
+            id: range.id,
+            sourceFrom: range.comparisonSourceFrom,
+            sourceTo: range.comparisonSourceTo,
+            translatedFrom: range.comparisonTranslationFrom,
+            translatedTo: range.comparisonTranslationTo,
+        })),
+        translationRanges: views.comparisonTranslationRanges,
+    });
+
+    const line = [...document.querySelectorAll('.cm-line')].find(candidate => (
+        candidate.textContent.includes('3.1 Execution State')
+    ));
+    assert.ok(line);
+    selectAndHighlight(document, dom.window, line);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(created.length, 1);
+    assert.equal(created[0].selectionContext.side, 'source');
+    assert.equal(created[0].annotation.text, '3.1 Execution State and Schema Authoring');
+    assert.ok(created[0].ranges.every(Boolean));
+    assert.equal(
+        markdownAnnotationRangeMatchesSource(
+            markdown,
+            created[0].ranges,
+            created[0].annotation.text
+        ),
+        true
+    );
+
+    editor.destroy();
+    dom.window.close();
+});
+
+test('creates a bilingual highlight from the SKILL.state schema paragraph', async () => {
+    const paragraph = [
+        'Unlike conversational runtimes, SKILL.state treats execution state as a first-class runtime abstraction.',
+        ' The state contains only information required for future execution and is represented using a structured schema defined for the domain.',
+        ' Schemas are authored once per domain rather than per task; for example, across all 100 diverse challenge instances in the InterCode CTF benchmark, the agent reuses a single static 5-field schema (discovered_flags, tested_hypotheses, active_files, working_dir, cmd_summary).',
+    ].join('');
+    const markdown = [
+        '### 3.1 Execution State and Schema Authoring',
+        '',
+        paragraph,
+    ].join('\n');
+    const blocks = collectMarkdownTranslationBlocks(markdown);
+    const views = createDocumentTranslationViews(markdown, blocks, [{
+        id: blocks[0].id,
+        markdown: '### 3.1 执行状态与模式设计',
+    }, {
+        id: blocks[1].id,
+        markdown: '与对话式运行时不同，SKILL.state将执行状态视为一等公民的运行时抽象。',
+    }]);
+    const created = [];
+    const dom = new JSDOM('<!doctype html><div id="editor"></div>', {
+        pretendToBeVisual: true,
+    });
+    const { document } = dom.window;
+    const editor = createInlineMarkdownEditor({
+        parent: document.querySelector('#editor'),
+        initialMarkdown: '',
+        createMarkdownAnnotation: async (annotation, selectionContext) => {
+            const ranges = annotation.ranges.map(range => (
+                mapComparisonRangeToSource(range, views.blockRanges)
+            ));
+            created.push({ annotation, selectionContext, ranges });
+            return annotation;
+        },
+    });
+    editor.setDocument({
+        markdown: views.comparisonMarkdown,
+        sourceActionRanges: views.blockRanges.map(range => ({
+            from: range.comparisonSourceFrom,
+            to: range.comparisonSourceTo,
+        })),
+        translationPairs: views.blockRanges.map(range => ({
+            id: range.id,
+            sourceFrom: range.comparisonSourceFrom,
+            sourceTo: range.comparisonSourceTo,
+            translatedFrom: range.comparisonTranslationFrom,
+            translatedTo: range.comparisonTranslationTo,
+        })),
+        translationRanges: views.comparisonTranslationRanges,
+    });
+
+    const start = textNodeContaining(
+        document.querySelector('.cm-content'),
+        'Unlike conversational runtimes'
+    );
+    const end = textNodeContaining(
+        document.querySelector('.cm-content'),
+        'cmd_summary'
+    );
+    assert.ok(start);
+    assert.ok(end);
+    selectAndHighlight(document, dom.window, range => {
+        range.setStart(
+            start,
+            start.textContent.indexOf('Unlike conversational runtimes')
+        );
+        range.setEnd(
+            end,
+            Math.min(
+                end.textContent.length,
+                end.textContent.indexOf('cmd_summary') + 'cmd_summary'.length
+            )
+        );
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    assert.equal(created.length, 1);
+    assert.equal(created[0].selectionContext.side, 'source');
+    assert.ok(created[0].ranges.every(Boolean));
+    assert.equal(
+        markdownAnnotationRangeMatchesSource(
+            markdown,
+            created[0].ranges,
+            created[0].annotation.text
+        ),
+        true
+    );
+
+    editor.destroy();
+    dom.window.close();
+});

--- a/test/markdown-citations.test.js
+++ b/test/markdown-citations.test.js
@@ -1117,6 +1117,37 @@ test('maps alphabetic author superscripts to affiliations and ignores symbols', 
     );
 });
 
+test('maps affiliation numbers before trailing latex author-note commands', () => {
+    const markdown = [
+        '# Repo-To-Skill',
+        '',
+        'Jianyu Chen $^{1,2\\dagger}$, Hongjin Qian $^{1\\dagger\\dagger}$',
+        '',
+        '$^{1}$ Beijing Academy of Artificial Intelligence',
+        '',
+        '$^{2}$ Renmin University of China',
+        '',
+        '## Abstract',
+        '',
+        'Body text.',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.deepEqual(
+        result.citations.map(citation => ({
+            label: markdown.slice(citation.from, citation.to),
+            kind: citation.kind,
+            targetIds: citation.referenceIds,
+        })),
+        [
+            { label: '1', kind: 'affiliation', targetIds: ['affiliation:1'] },
+            { label: '2', kind: 'affiliation', targetIds: ['affiliation:2'] },
+            { label: '1', kind: 'affiliation', targetIds: ['affiliation:1'] },
+        ]
+    );
+});
+
 test('recovers plain affiliation markers emitted between superscript definitions', () => {
     const markdown = [
         '# Paper',

--- a/test/markdown-editor-styles.test.js
+++ b/test/markdown-editor-styles.test.js
@@ -299,6 +299,12 @@ test('keeps rendered display math spacing inside the CodeMirror block widget', (
         '.markdown-editor-host > .cm-editor .cm-mktero-math-display annotation',
     ].join('\n'));
     assert.match(annotation, /display:\s*none/);
+
+    const mathHighlight = ruleBody(
+        '.markdown-editor-host > .cm-editor .cm-mktero-math-display > .cm-mktero-pdf-annotation'
+    );
+    assert.match(mathHighlight, /display:\s*inline-block/);
+    assert.match(mathHighlight, /padding:\s*0\.2em 0\.75em/);
 });
 
 test('keeps rendered figure spacing inside the CodeMirror block widget', () => {
@@ -784,6 +790,11 @@ test('styles citation popups and temporary reference highlights', () => {
     assert.match(superscriptCitation, /font-size:\s*0\.75em/);
     assert.match(superscriptCitation, /line-height:\s*1/);
     assert.match(superscriptCitation, /vertical-align:\s*super/);
+
+    const superscriptMath = ruleBody(
+        '.markdown-editor-host > .cm-editor .cm-mktero-math.cm-mktero-citation-superscript'
+    );
+    assert.match(superscriptMath, /vertical-align:\s*super/);
 
     const affiliationMarker = ruleBody(
         '.markdown-editor-host > .cm-editor .cm-mktero-affiliation-marker'

--- a/test/markdown-local-annotations.test.js
+++ b/test/markdown-local-annotations.test.js
@@ -1156,6 +1156,21 @@ test('reports an unreadable local annotation store without breaking conversion',
     assert.deepEqual(errors, ['private filesystem detail']);
 });
 
+test('matches a display math annotation to its formula text', () => {
+    const formula = '(R_t, \\Delta\\Sigma_t, a_t)';
+    const markdown = `Intro.\n\n$$\n${formula}\n$$\n\nBody.`;
+    const from = markdown.indexOf('$$');
+    const to = markdown.lastIndexOf('$$') + 2;
+    assert.equal(
+        markdownAnnotationRangeMatchesSource(
+            markdown,
+            [{ from, to }],
+            formula
+        ),
+        true
+    );
+});
+
 test('matches a split Markdown annotation that skipped chrome', () => {
     const markdown = 'Hello\n\n12\n\nWorld';
     assert.equal(

--- a/test/markdown-source-map.test.js
+++ b/test/markdown-source-map.test.js
@@ -42,12 +42,42 @@ test('does not resolve a PDF page hint from ambiguous source evidence', () => {
     assert.equal(resolvePDFPageIndexHint([
         entry,
         { ...entry, markdownFrom: 20, markdownTo: 60 },
-    ], { from: 24, to: 46 }, 100), null);
+    ], { from: 24, to: 46 }, 100), 3);
     assert.equal(resolvePDFPageIndexHint(
         [entry],
         { from: 70, to: 90 },
         100
-    ), null);
+    ), 3);
+});
+
+test('resolves a PDF page hint from overlapping or nearby source entries', () => {
+    const sourceMap = [{
+        type: 'text',
+        markdownFrom: 0,
+        markdownTo: 40,
+        locations: [{ pageIndex: 2, bbox: [100, 400, 900, 500] }],
+    }, {
+        type: 'equation',
+        markdownFrom: 42,
+        markdownTo: 70,
+        locations: [{ pageIndex: 2, bbox: [200, 250, 800, 320] }],
+    }, {
+        type: 'text',
+        markdownFrom: 72,
+        markdownTo: 110,
+        locations: [{ pageIndex: 2, bbox: [100, 100, 900, 200] }],
+    }];
+
+    assert.equal(resolvePDFPageIndexHint(
+        sourceMap,
+        { from: 40, to: 72 },
+        120
+    ), 2);
+    assert.equal(resolvePDFPageIndexHint(
+        sourceMap,
+        { from: 38, to: 74 },
+        120
+    ), 2);
 });
 
 test('maps unique MinerU content to Markdown blocks and keeps merged locations', () => {

--- a/test/markdown-visible-text.test.js
+++ b/test/markdown-visible-text.test.js
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
     createVisibleMarkdownTextIndex,
+    visibleMarkdownTextForRanges,
 } from '../src/markdown/markdown-visible-text.js';
 
 test('indexes rendered inline math without its delimiters', () => {
@@ -118,5 +119,27 @@ test('hides extra ranges in the visible Markdown index', () => {
     const markdown = 'Hello **x** World';
     const index = createVisibleMarkdownTextIndex(markdown, [{ from: 6, to: 11 }]);
     assert.equal(index.text, 'Hello  World');
+});
+
+test('strips heading marks from visible Markdown range text', () => {
+    const markdown = '### 3.1 Execution State and Schema Authoring\n\nBody.';
+    assert.equal(
+        visibleMarkdownTextForRanges(markdown, [{
+            from: 0,
+            to: markdown.indexOf('\n'),
+        }]).trim(),
+        '3.1 Execution State and Schema Authoring'
+    );
+});
+
+test('strips display math delimiters from visible Markdown range text', () => {
+    const formula = '(R_t, \\Delta\\Sigma_t, a_t)';
+    const markdown = `Intro.\n\n$$\n${formula}\n$$\n\nBody.`;
+    const from = markdown.indexOf('$$');
+    const to = markdown.lastIndexOf('$$') + 2;
+    assert.equal(
+        visibleMarkdownTextForRanges(markdown, [{ from, to }]).trim(),
+        formula
+    );
 });
 

--- a/test/markdown-window.test.js
+++ b/test/markdown-window.test.js
@@ -6,6 +6,10 @@ import { createLocalization } from '../src/i18n/localization.js';
 import { createMarkdownTabView } from '../src/ui/markdown-window.js';
 import { createEvidenceSnippet } from '../src/markdown/markdown-evidence.js';
 import { selectExportMarkdown } from '../src/markdown/export-markdown-selector.js';
+import {
+    collectMarkdownTranslationBlocks,
+    createDocumentTranslationViews,
+} from '../src/markdown/markdown-translation-blocks.js';
 
 const MARKDOWN_STYLES = readFileSync(
     new URL('../ui/markdown.css', import.meta.url),
@@ -1810,6 +1814,139 @@ test('keeps source annotations and evidence actions on bilingual source blocks',
         text: '\u8bd1\u6587',
         ranges: [{ from: 36, to: 38 }],
     }), /source/i);
+    view.destroy();
+});
+
+test('creates bilingual heading annotations from visible text', async () => {
+    const created = [];
+    let editorOptions;
+    const markdown = '### 3.1 Execution State and Schema Authoring\n\nBody paragraph.';
+    const blocks = collectMarkdownTranslationBlocks(markdown);
+    const views = createDocumentTranslationViews(markdown, blocks, [{
+        id: blocks[0].id,
+        markdown: '### 3.1 执行状态与模式设计',
+    }, {
+        id: blocks[1].id,
+        markdown: '正文。',
+    }]);
+    const heading = views.blockRanges[0];
+    const model = createModel({
+        status: 'ready',
+        progress: 100,
+        markdown,
+        translationStatus: 'ready',
+        translationView: 'compare',
+        translatedMarkdown: views.translatedMarkdown,
+        comparisonMarkdown: views.comparisonMarkdown,
+        translationBlockRanges: views.blockRanges,
+        onCreateMarkdownAnnotation: annotation => {
+            created.push(annotation);
+            return {
+                ...annotation,
+                id: 'mktero-local-heading',
+                source: 'markdown',
+                type: 'highlight',
+            };
+        },
+    });
+    const { view } = createView(model, {}, {
+        editorFactory(options) {
+            editorOptions = options;
+            return {
+                setDocument() {},
+                setCorrectionState() {},
+                refreshRendering() {},
+                destroy() {},
+            };
+        },
+    });
+
+    await editorOptions.createMarkdownAnnotation({
+        text: '3.1 Execution State and Schema Authoring',
+        comment: '',
+        color: '#2ea8e5',
+        ranges: [{
+            from: heading.comparisonSourceFrom,
+            to: heading.comparisonSourceTo,
+        }],
+    }, { side: 'source' });
+
+    assert.deepEqual(created[0].ranges, [{
+        from: heading.sourceFrom,
+        to: heading.sourceTo,
+    }]);
+    assert.equal(created[0].text, '3.1 Execution State and Schema Authoring');
+    view.destroy();
+});
+
+test('creates bilingual display math annotations from formula text', async () => {
+    const created = [];
+    let editorOptions;
+    const formula = '(R_t, \\Delta\\Sigma_t, a_t)';
+    const markdown = [
+        'Given the current execution context.',
+        '',
+        '$$',
+        formula,
+        '$$',
+        '',
+        'where R_t denotes the trace.',
+    ].join('\n');
+    const blocks = collectMarkdownTranslationBlocks(markdown);
+    const translations = blocks.filter(block => block.translatable).map(block => ({
+        id: block.id,
+        markdown: `${block.markdown} 译文。`,
+    }));
+    const views = createDocumentTranslationViews(markdown, blocks, translations);
+    const mathBlock = views.blockRanges.find(range => (
+        markdown.slice(range.sourceFrom, range.sourceTo).includes('$$')
+    ));
+    const model = createModel({
+        status: 'ready',
+        progress: 100,
+        markdown,
+        translationStatus: 'ready',
+        translationView: 'compare',
+        translatedMarkdown: views.translatedMarkdown,
+        comparisonMarkdown: views.comparisonMarkdown,
+        translationBlockRanges: views.blockRanges,
+        onCreateMarkdownAnnotation: annotation => {
+            created.push(annotation);
+            return {
+                ...annotation,
+                id: 'mktero-local-math',
+                source: 'markdown',
+                type: 'highlight',
+            };
+        },
+    });
+    const { view } = createView(model, {}, {
+        editorFactory(options) {
+            editorOptions = options;
+            return {
+                setDocument() {},
+                setCorrectionState() {},
+                refreshRendering() {},
+                destroy() {},
+            };
+        },
+    });
+
+    await editorOptions.createMarkdownAnnotation({
+        text: formula,
+        comment: '',
+        color: '#2ea8e5',
+        ranges: [{
+            from: mathBlock.comparisonSourceFrom,
+            to: mathBlock.comparisonSourceTo,
+        }],
+    }, { side: 'source' });
+
+    assert.deepEqual(created[0].ranges, [{
+        from: mathBlock.sourceFrom,
+        to: mathBlock.sourceTo,
+    }]);
+    assert.equal(created[0].text, formula);
     view.destroy();
 });
 

--- a/test/pdf-annotation-locator.test.js
+++ b/test/pdf-annotation-locator.test.js
@@ -1165,6 +1165,86 @@ test('matches PDF whitespace, signed numbers, dehyphenation, and CJK text', asyn
     locator.dispose();
 });
 
+test('locates Delta-Sigma formula prose from LaTeX Markdown', async () => {
+    const locator = await createSyntheticLocator([[
+        createTextItem('ΔΣ_t is a structured state update', { hasEOL: true }),
+    ]]);
+
+    const located = await locator.locate(
+        42,
+        '\\Delta\\Sigma_{t} is a structured state update',
+        { pdfPageIndexHint: 0 }
+    );
+
+    assert.equal(located.position.pageIndex, 0);
+    assert.equal(located.position.rects.length, 1);
+    locator.dispose();
+});
+
+test('uses an equation tag to choose one of several same-page formula matches', async () => {
+    const locator = await createSyntheticLocator([[
+        createTextItem('(Rt, ΔΣt, at) using the LLM', { y: 700, hasEOL: true }),
+        createTextItem('(Rt, ΔΣt, at), (3)', { y: 640, hasEOL: true }),
+    ]]);
+
+    const located = await locator.locate(
+        42,
+        '(R _ {t}, \\Delta \\Sigma_ {t}, a _ {t}), \\tag{3}',
+        { pdfPageIndexHint: 0 }
+    );
+
+    assert.equal(located.position.pageIndex, 0);
+    locator.dispose();
+});
+
+test('uses a page hint to choose one of several formula matches', async () => {
+    const locator = await createSyntheticLocator([
+        [createTextItem('(Rt, ΔΣt, at) using the LLM', { y: 700, hasEOL: true })],
+        [createTextItem('(Rt, ΔΣt, at), (3)', { y: 640, hasEOL: true })],
+    ]);
+
+    const located = await locator.locate(
+        42,
+        '(R _ {t}, \\Delta \\Sigma_ {t}, a _ {t}), \\tag{3}',
+        { pdfPageIndexHint: 1 }
+    );
+
+    assert.equal(located.position.pageIndex, 1);
+    locator.dispose();
+});
+
+test('locates a tagged display formula with spaced Delta Sigma', async () => {
+    const locator = await createSyntheticLocator([[
+        createTextItem('(Rt, ΔΣt, at), (3)', { hasEOL: true }),
+    ]]);
+
+    const located = await locator.locate(
+        42,
+        '(R _ {t}, \\Delta \\Sigma_ {t}, a _ {t}), \\tag{3}',
+        { pdfPageIndexHint: 0 }
+    );
+
+    assert.equal(located.position.pageIndex, 0);
+    assert.equal(located.position.rects.length, 1);
+    locator.dispose();
+});
+
+test('locates a tagged display formula from spaced LaTeX Markdown', async () => {
+    const locator = await createSyntheticLocator([[
+        createTextItem('At = (P, Σt, Ot), (2)', { hasEOL: true }),
+    ]]);
+
+    const located = await locator.locate(
+        42,
+        'A _ {t} = (P, \\Sigma_t, O _ {t}),\\tag{2}',
+        { pdfPageIndexHint: 0 }
+    );
+
+    assert.equal(located.position.pageIndex, 0);
+    assert.equal(located.position.rects.length, 1);
+    locator.dispose();
+});
+
 test('matches Markdown LaTeX formulas against PDF math text', async () => {
     const locator = await createSyntheticLocator([[
         createTextItem(

--- a/test/pdf-annotation-text.test.js
+++ b/test/pdf-annotation-text.test.js
@@ -152,6 +152,28 @@ test('normalizes LaTeX Greek symbols and braced subscripts from PDF text', () =>
     assert.equal(normalizePdfAnnotationText('\\input_{secret}'), '\\input_{secret}');
     assert.equal(normalizePdfAnnotationText('\\operatorname{foo}_{bar}'), '\\operatorname{foo}_{bar}');
     assert.equal(normalizePdfAnnotationText('\\tau_i'), 'τi');
+    assert.equal(
+        normalizePdfAnnotationText('A _ {t} = (P, \\Sigma_t, O _ {t}),\\tag{2}'),
+        'At=(P, Σt, Ot),(2)'
+    );
+    assert.equal(
+        normalizePdfAnnotationText(
+            '(R _ {t}, \\Delta \\Sigma_ {t}, a _ {t}), \\tag{3}'
+        ),
+        '(Rt, ΔΣt, at),(3)'
+    );
+    assert.equal(
+        normalizePdfAnnotationText('\\Delta\\Sigma_{t} is a structured state update'),
+        'ΔΣt is a structured state update'
+    );
+    assert.equal(
+        normalizePdfAnnotationText('\\Delta\\Sigma_{t} is a structured state update'),
+        normalizePdfAnnotationText('ΔΣ_t is a structured state update')
+    );
+    assert.equal(
+        normalizePdfAnnotationText('\\Delta \\Sigma_{t}'),
+        normalizePdfAnnotationText('∆Σt')
+    );
     assert.equal(normalizePdfAnnotationText('literal \\_value'), 'literal \\_value');
     assert.equal(normalizePdfAnnotationText('\\\\tau_i'), '\\\\tau_i');
     assert.equal(normalizePdfAnnotationText('\\\\tau_{i}'), '\\\\tau_{i}');

--- a/ui/markdown.css
+++ b/ui/markdown.css
@@ -2768,6 +2768,10 @@ main {
     vertical-align: super;
 }
 
+.markdown-editor-host > .cm-editor .cm-mktero-math.cm-mktero-citation-superscript {
+    vertical-align: super;
+}
+
 .markdown-editor-host > .cm-editor .cm-mktero-citation:hover {
     background: color-mix(in srgb, var(--accent) 10%, transparent);
 }
@@ -4449,6 +4453,14 @@ main {
     font-size: 1em;
     -moz-user-select: text;
     user-select: text;
+}
+
+.markdown-editor-host > .cm-editor .cm-mktero-math-display > .cm-mktero-pdf-annotation {
+    display: inline-block;
+    max-width: 100%;
+    padding: 0.2em 0.75em;
+    border-radius: 6px;
+    cursor: pointer;
 }
 
 .markdown-editor-host > .cm-editor .cm-mktero-math annotation,


### PR DESCRIPTION
## Summary
- Compare Markdown highlight text with visible rendered text so heading marks, bilingual chrome, and `$$` delimiters no longer fail annotation create.
- Recover PDF overlay matches across line-end hyphenation, spaced LaTeX subscripts, `\tag{N}`, and Delta-Sigma glyphs; resolve overlapping/nearby source-map page hints.
- Tint display-math formula highlights and KaTeX-render leftover `\dagger`/`\ddagger` author notes while keeping affiliation numbers clickable.

## Test plan
- [x] `npm run check`
- [x] `npm test`
- [x] `npm run build`
- [ ] Install `build/mktero-0.3.8.xpi`, reopen SKILL.state, highlight a heading and a display formula, confirm the annotation saves and the formula highlight is visible
- [ ] On the same paper, click PDF navigation for a hyphen-split highlight and a tagged formula
- [ ] Open Repo-To-Skill and confirm author `\dagger` renders as KaTeX (not raw TeX) with working affiliation popups