### PR TITLE
feat: recognize ACM/natbib square-bracket author-year citations

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ The popup header contains only the target-library picker. Each reference shows
 its status on the left and its own import, retry, copy, or open action on the
 right, so actions always apply to one visible reference.
 
-Grouped author-year citations resolve every matched bibliography entry. If PDF
+Grouped author-year citations resolve every matched bibliography entry, including ACM/natbib square-bracket forms such as `Lewis et al. [2020]` and `[Kirkpatrick et al., 2017; Wei et al., 2026]`. If PDF
 conversion inserts a stray heading inside an APA-style bibliography, Mktero
 continues the reference list only when multiple bibliography-shaped entries
 clearly resume after it, so a genuine author note still ends the list.

--- a/src/markdown/markdown-citations.js
+++ b/src/markdown/markdown-citations.js
@@ -1102,45 +1102,75 @@ function findAuthorYearCitations(markdown, bodyFrom, bodyEnd, references) {
     const body = markdown.slice(bodyFrom, bodyEnd);
     const citations = [];
     const referencesByYear = groupReferencesByYear(references);
-    const parentheticalPattern = /[（(]((?:[^()（）\r\n]|\r?\n(?!\r?\n)){1,240})[)）]/g;
-    for (const match of body.matchAll(parentheticalPattern)) {
-        const matched = [];
-        for (const segment of match[1].split(/[;；]/)) {
-            const authorYear = parseAuthorYearSegment(segment);
-            if (!authorYear) continue;
-            for (const year of authorYear.years) {
-                matched.push(...matchAuthorReferences(
-                    referencesByYear,
-                    authorYear.authors,
-                    year
+    const parentheticalContainers = [
+        {
+            pattern: /[（(]((?:[^()（）\r\n]|\r?\n(?!\r?\n)){1,240})[)）]/g,
+            skip: () => false,
+        },
+        {
+            pattern: /\[((?:[^\[\]\r\n]|\r?\n(?!\r?\n)){1,240})\]/g,
+            skip: squareBracketLooksLikeMarkup,
+        },
+    ];
+    for (const { pattern, skip } of parentheticalContainers) {
+        for (const match of body.matchAll(pattern)) {
+            if (skip(body, match)) continue;
+            const matched = [];
+            for (const segment of match[1].split(/[;；]/)) {
+                const authorYear = parseAuthorYearSegment(segment);
+                if (!authorYear) continue;
+                for (const year of authorYear.years) {
+                    matched.push(...matchAuthorReferences(
+                        referencesByYear,
+                        authorYear.authors,
+                        year
+                    ));
+                }
+            }
+            const unique = uniqueReferences(matched);
+            if (unique.length) {
+                citations.push(createCitation(
+                    bodyFrom + match.index,
+                    bodyFrom + match.index + match[0].length,
+                    unique
                 ));
             }
         }
-        const unique = uniqueReferences(matched);
-        if (unique.length) {
+    }
+
+    const narrativePatterns = [
+        /(^|[^\p{L}\p{N}_])([\p{L}][\p{L}'’.-]*(?:\s+et\s+al\.?|\s+(?:&|and)\s+[\p{L}][\p{L}'’.-]*)?)\s*[（(]([^()（）\r\n]{1,120})[)）]/giu,
+        /(^|[^\p{L}\p{N}_])([\p{L}][\p{L}'’.-]*(?:\s+et\s+al\.?|\s+(?:&|and)\s+[\p{L}][\p{L}'’.-]*)?)\s*\[([^\[\]\r\n]{1,120})\]/giu,
+    ];
+    for (const pattern of narrativePatterns) {
+        for (const match of body.matchAll(pattern)) {
+            if (squareBracketNarrativeLooksLikeMarkup(body, match)) continue;
+            const years = parseYearSequence(match[3]);
+            const matched = uniqueReferences(years.flatMap(year => (
+                matchAuthorReferences(referencesByYear, match[2], year)
+            )));
+            if (!matched.length) continue;
+            const from = bodyFrom + match.index + match[1].length;
             citations.push(createCitation(
-                bodyFrom + match.index,
+                from,
                 bodyFrom + match.index + match[0].length,
-                unique
+                matched
             ));
         }
     }
-
-    const narrativePattern = /(^|[^\p{L}\p{N}_])([\p{L}][\p{L}'’.-]*(?:\s+et\s+al\.?|\s+(?:&|and)\s+[\p{L}][\p{L}'’.-]*)?)\s*[（(]([^()（）\r\n]{1,120})[)）]/giu;
-    for (const match of body.matchAll(narrativePattern)) {
-        const years = parseYearSequence(match[3]);
-        const matched = uniqueReferences(years.flatMap(year => (
-            matchAuthorReferences(referencesByYear, match[2], year)
-        )));
-        if (!matched.length) continue;
-        const from = bodyFrom + match.index + match[1].length;
-        citations.push(createCitation(
-            from,
-            bodyFrom + match.index + match[0].length,
-            matched
-        ));
-    }
     return citations;
+}
+
+function squareBracketLooksLikeMarkup(body, match) {
+    const before = body[match.index - 1] || '';
+    const after = body[match.index + match[0].length] || '';
+    return before === '!' || ['(', '[', ':'].includes(after);
+}
+
+function squareBracketNarrativeLooksLikeMarkup(body, match) {
+    if (!match[0].endsWith(']')) return false;
+    const after = body[match.index + match[0].length] || '';
+    return ['(', '[', ':'].includes(after);
 }
 
 function parseAuthorYearSegment(segment) {

--- a/test/markdown-citations.test.js
+++ b/test/markdown-citations.test.js
@@ -1695,6 +1695,91 @@ test('matches parenthetical and narrative author-year citations', () => {
     );
 });
 
+test('matches ACM natbib square-bracket author-year citations', () => {
+    const markdown = [
+        '# Selective Forgetting',
+        '',
+        'Flat retrieval Lewis et al. [2020] is sensitive to noise Gao et al. [2023].',
+        'Graphs store entities Ji et al. [2021], Peng et al. [2023].',
+        'Forgetting is required [Kirkpatrick et al., 2017; Wei et al., 2026].',
+        '',
+        '## References',
+        '',
+        'Yunfan Gao, Yun Xiong, Xinyu Gao, Kangxiang Jia, Jinliu Pan, Yuxi Bi, '
+            + 'Yi Dai, Jiawei Sun, Meng Wang, and Haofen Wang. Retrieval-augmented '
+            + 'generation for large language models: A survey. arXiv preprint '
+            + 'arXiv:2312.10997, 2023.',
+        '',
+        'Shaoxiong Ji, Shirui Pan, Erik Cambria, Pekka Marttinen, and Philip S Yu. '
+            + 'A survey on knowledge graphs: Representation, acquisition, and '
+            + 'applications. IEEE transactions on neural networks and learning '
+            + 'systems, 33(2):494–514, 2021.',
+        '',
+        'James Kirkpatrick, Razvan Pascanu, Neil Rabinowitz, Joel Veness, '
+            + 'Guillaume Desjardins, Andrei A Rusu, Kieran Milan, John Quan, '
+            + 'Tiago Ramalho, Agnieszka Grabska-Barwinska, et al. Overcoming '
+            + 'catastrophic forgetting in neural networks. Proceedings of the '
+            + 'national academy of sciences, 114(13):3521–3526, 2017.',
+        '',
+        'Patrick Lewis, Ethan Perez, Aleksandra Piktus, Fabio Petroni, '
+            + 'Vladimir Karpukhin, Naman Goyal, Heinrich Küttler, Mike Lewis, '
+            + 'Wen-tau Yih, Tim Rocktäschel, et al. Retrieval-augmented generation '
+            + 'for knowledge-intensive nlp tasks. volume 33, pages 9459–9474, 2020.',
+        '',
+        'Ciyuan Peng, Feng Xia, Mehdi Naseriparsa, and Francesco Osborne. '
+            + 'Knowledge graphs: Opportunities and challenges. 2023. '
+            + 'URL https://arxiv.org/abs/2303.13948.',
+        '',
+        'Lei Wei, Xu Dong, Xiao Peng, Niantao Xie, and Bin Wang. Fademem: '
+            + 'Biologically-inspired forgetting for efficient agent memory. '
+            + 'pages 4011–4015, 2026.',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.equal(result.references.length, 6);
+    assert.deepEqual(
+        result.citations.map(citation => ({
+            label: markdown.slice(citation.from, citation.to),
+            referenceIds: citation.referenceIds,
+        })),
+        [
+            { label: 'Lewis et al. [2020]', referenceIds: ['reference:4'] },
+            { label: 'Gao et al. [2023]', referenceIds: ['reference:1'] },
+            { label: 'Ji et al. [2021]', referenceIds: ['reference:2'] },
+            { label: 'Peng et al. [2023]', referenceIds: ['reference:5'] },
+            {
+                label: '[Kirkpatrick et al., 2017; Wei et al., 2026]',
+                referenceIds: ['reference:3', 'reference:6'],
+            },
+        ]
+    );
+});
+
+test('ignores markdown links when matching square-bracket author-year citations', () => {
+    const markdown = [
+        '# Paper',
+        '',
+        'See [Lewis et al., 2020](https://example.org/lewis) and Smith et al. [2020].',
+        '',
+        '## References',
+        '',
+        'Patrick Lewis, Ethan Perez, Aleksandra Piktus, Fabio Petroni, '
+            + 'Vladimir Karpukhin, Naman Goyal, Heinrich Küttler, Mike Lewis, '
+            + 'Wen-tau Yih, Tim Rocktäschel, et al. Retrieval-augmented generation '
+            + 'for knowledge-intensive nlp tasks. volume 33, pages 9459–9474, 2020.',
+        '',
+        'Smith, A., Jones, B., & Lee, C. (2020). Follow-up study.',
+    ].join('\n');
+
+    const result = analyzeMarkdownCitations(markdown);
+
+    assert.deepEqual(
+        result.citations.map(citation => markdown.slice(citation.from, citation.to)),
+        ['Smith et al. [2020]']
+    );
+});
+
 test('continues an author-year reference list after an embedded author note', () => {
     const citation = '(Blood & Zatorre, 2001; Blood et al., 1999; '
         + 'Koelsch, Fritz, Schulze, Alsop, & Schlaug, 2005; '


### PR DESCRIPTION
## Summary
- Recognize ACM/natbib author-year citations that put the year in square brackets, including `Lewis et al. [2020]` and `[Kirkpatrick et al., 2017; Wei et al., 2026]`.
- Skip Markdown links and reference-style markup so `[text](url)` is not treated as a citation.

## Test plan
- [x] `node --test test/markdown-citations.test.js`
- [x] `npm run check`
- [x] `npm test`
- [x] `npm run build`