### PR TITLE
chore: release 0.3.10

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Mktero",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Display opened Zotero PDFs as Markdown",
   "author": "Tony",
   "icons": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mktero",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mktero",
-      "version": "0.3.9",
+      "version": "0.3.10",
       "dependencies": {
         "@ai-sdk/alibaba": "^2.0.41",
         "@ai-sdk/anthropic": "^4.0.49",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mktero",
-  "version": "0.3.9",
+  "version": "0.3.10",
   "description": "Display opened Zotero PDFs as Markdown",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Updates all Mktero version fields to 0.3.10.

Release checks completed with Node 24.15.0:
- npm ci
- npm run check
- npm test
- npm run build